### PR TITLE
Minor fixes.

### DIFF
--- a/semantic-ui-demo/src/main/scala/react/semanticui/demo/elements/IconsComponent.scala
+++ b/semantic-ui-demo/src/main/scala/react/semanticui/demo/elements/IconsComponent.scala
@@ -27,7 +27,7 @@ object IconsComponent {
   val IconAdd                        = Icon(name = "add")
   val IconCircleThin                 = Icon(name = "circle thin")
   val IconUser                       = Icon(name = "user")
-  val AllSizes: List[SemanticSize]   = List(Mini, Tiny, Small, Medium, Large, Big, Huge, Massive)
+  val AllSizes: List[SemanticSize]   = List(Mini, Tiny, Small, Large, Big, Huge, Massive)
   val AllColors: List[SemanticColor] =
     List(Red, Orange, Yellow, Olive, Green, Teal, Blue, Violet, Purple, Pink, Brown, Grey, Black)
   private val sampleIcons            = Map("mail outline" -> IconMailOutline, "search" -> IconSearch)

--- a/semantic-ui-demo/src/main/scala/react/semanticui/demo/elements/LabelsComponent.scala
+++ b/semantic-ui-demo/src/main/scala/react/semanticui/demo/elements/LabelsComponent.scala
@@ -68,29 +68,25 @@ object LabelsComponent {
             List(
               <.div(
                 ^.cls := "column docs-icon-set-column",
-                Label(as = "a", image = true).apply(<.img(
-                                                      ^.src := WebpackResources.AdaAvatar.resource
-                                                    ),
-                                                    "Ade"
+                Label(as = <.a, image = true)(
+                  <.img(^.src := WebpackResources.AdaAvatar.resource),
+                  "Ade"
                 )
               ),
               <.div(
                 ^.cls := "column docs-icon-set-column",
-                Label(as = "a", image = true, color = Blue).apply(
-                  <.img(
-                    ^.src := WebpackResources.AdaAvatar.resource
-                  ),
+                Label(as = "a", image = true, color = Blue)(
+                  <.img(^.src := WebpackResources.AdaAvatar.resource),
                   "Ade",
                   LabelDetail("Friend")
                 )
               ),
               <.div(
                 ^.cls := "column docs-icon-set-column",
-                Label(as = "a", image = true).apply(<.img(
-                                                      ^.src := WebpackResources.AdaAvatar.resource
-                                                    ),
-                                                    "Ade",
-                                                    IconDelete
+                Label(as = "a", image = true)(
+                  <.img(^.src := WebpackResources.AdaAvatar.resource),
+                  "Ade",
+                  IconDelete
                 )
               )
             ).toTagMod

--- a/semantic-ui/src/main/scala/react/semanticui/elements/header/Header.scala
+++ b/semantic-ui/src/main/scala/react/semanticui/elements/header/Header.scala
@@ -19,13 +19,13 @@ import js.annotation._
 import js.|
 
 final case class Header(
+  content:                js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
   as:                     js.UndefOr[AsC] = js.undefined,
   attached:               js.UndefOr[HeaderAttached] = js.undefined,
   block:                  js.UndefOr[Boolean] = js.undefined,
   className:              js.UndefOr[String] = js.undefined,
   clazz:                  js.UndefOr[Css] = js.undefined,
   color:                  js.UndefOr[SemanticColor] = js.undefined,
-  content:                js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
   disabled:               js.UndefOr[Boolean] = js.undefined,
   dividing:               js.UndefOr[Boolean] = js.undefined,
   floated:                js.UndefOr[SemanticFloat] = js.undefined,
@@ -173,7 +173,4 @@ object Header {
 
   private val component =
     JsFnComponent[HeaderProps, Children.Varargs](RawComponent)
-
-  def apply(modifiers: TagMod*): Header =
-    Header(modifiers = modifiers)
 }

--- a/semantic-ui/src/main/scala/react/semanticui/elements/label/LabelDetail.scala
+++ b/semantic-ui/src/main/scala/react/semanticui/elements/label/LabelDetail.scala
@@ -16,10 +16,10 @@ import scala.scalajs.js
 import js.annotation._
 
 final case class LabelDetail(
+  content:                js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
   as:                     js.UndefOr[AsC] = js.undefined,
   className:              js.UndefOr[String] = js.undefined,
   clazz:                  js.UndefOr[Css] = js.undefined,
-  content:                js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
   override val modifiers: Seq[TagMod] = Seq.empty
 ) extends GenericComponentPAC[LabelDetail.LabelDetailProps, LabelDetail] {
   override protected def cprops                     = LabelDetail.props(this)
@@ -45,9 +45,7 @@ object LabelDetail {
     var content: js.UndefOr[SemanticShorthandContent] = js.native
   }
 
-  def props(
-    q: LabelDetail
-  ): LabelDetailProps = {
+  def props(q: LabelDetail): LabelDetailProps = {
     val p = q.as.toJsObject[LabelDetailProps]
     q.as.toJs.foreachUnchecked(v => p.as = v)
     (q.className, q.clazz).toJs.foreach(v => p.className = v)
@@ -57,7 +55,4 @@ object LabelDetail {
 
   private val component =
     JsComponent[LabelDetailProps, Children.Varargs, Null](RawComponent)
-
-  def apply(modifiers: TagMod*): LabelDetail =
-    new LabelDetail(modifiers = modifiers)
 }

--- a/semantic-ui/src/main/scala/react/semanticui/package.scala
+++ b/semantic-ui/src/main/scala/react/semanticui/package.scala
@@ -41,6 +41,9 @@ package semanticui {
     import elements.placeholder.{PlaceholderLine => SUIPlaceholderLine}
     import elements.placeholder.{PlaceholderHeader => SUIPlaceholderHeader}
 
+    implicit def tagOf2AsC[T, N <: TopNode](tagOf: T)(implicit ev: T => TagOf[N]): js.UndefOr[AsC] =
+      As.AsTag(ev(tagOf))
+
     protected def removeAs[P <: js.Object](p: P): P =
       filterProps(p, "as")
 
@@ -413,9 +416,6 @@ package object semanticui {
   type AsObj = js.Object
   type AsT   = String | AsFn | AsObj
   type AsC   = String | As
-
-  implicit def tagOf2AsC[T, N <: TopNode](tagOf: T)(implicit ev: T => TagOf[N]): js.UndefOr[AsC] =
-    As.AsTag(ev(tagOf))
 
   implicit class AsCUndef[T](val c: js.UndefOr[AsC]) extends AnyVal {
     def toJs: js.UndefOr[AsT] =

--- a/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuHeaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuHeaderSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.collections.menu
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class MenuHeaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuHeaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuHeaderSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.collections.menu
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class MenuHeaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuItemSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuItemSuite.scala
@@ -9,7 +9,7 @@ import react.common.GenericComponentPACOps
 import react.common.style.Css
 import react.common.syntax.vdom._
 import react.semanticui.elements.icon._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class MenuItemSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuItemSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuItemSuite.scala
@@ -9,7 +9,6 @@ import react.common.GenericComponentPACOps
 import react.common.style.Css
 import react.common.syntax.vdom._
 import react.semanticui.elements.icon._
-import react.semanticui.As.tagOf2AsC
 
 class MenuItemSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuMenuSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuMenuSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.collections.menu
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class MenuMenuSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuMenuSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuMenuSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.collections.menu
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class MenuMenuSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuSuite.scala
@@ -8,7 +8,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericComponentPACOps
 import react.common.style.Css
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class MenuSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/collections/menu/MenuSuite.scala
@@ -8,7 +8,6 @@ import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericComponentPACOps
 import react.common.style.Css
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class MenuSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/container/ContainerSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/container/ContainerSuite.scala
@@ -7,7 +7,7 @@ import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class ContainerSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/container/ContainerSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/container/ContainerSuite.scala
@@ -7,7 +7,6 @@ import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class ContainerSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/divider/DividerSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/divider/DividerSuite.scala
@@ -8,7 +8,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericComponentPACOps
 import react.common.syntax.vdom._
 import react.semanticui.elements.image.Image
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class DividerSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/divider/DividerSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/divider/DividerSuite.scala
@@ -8,7 +8,6 @@ import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericComponentPACOps
 import react.common.syntax.vdom._
 import react.semanticui.elements.image.Image
-import react.semanticui.As.tagOf2AsC
 
 class DividerSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/flag/FlagSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/flag/FlagSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.flag
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class FlagSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/flag/FlagSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/flag/FlagSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.flag
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class FlagSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderContentSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderContentSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.header
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class HeaderContentSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderContentSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderContentSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.header
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class HeaderContentSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderSubheaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderSubheaderSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.header
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class HeaderSubheaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderSubheaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderSubheaderSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.header
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class HeaderSubheaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderSuite.scala
@@ -7,7 +7,7 @@ import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class HeaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/header/HeaderSuite.scala
@@ -7,7 +7,6 @@ import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class HeaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/image/ImageSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/image/ImageSuite.scala
@@ -8,7 +8,6 @@ import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
 import react.semanticui.elements.icon._
-import react.semanticui.As.tagOf2AsC
 
 class ImageSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/image/ImageSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/image/ImageSuite.scala
@@ -8,7 +8,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
 import react.semanticui.elements.icon._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class ImageSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListContentSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListContentSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class ListContentSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListContentSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListContentSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class ListContentSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListDescriptionSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListDescriptionSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class ListDescriptionSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListDescriptionSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListDescriptionSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class ListDescriptionSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListHeaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListHeaderSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class ListHeaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListHeaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListHeaderSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class ListHeaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListItemSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListItemSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class ListItemSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListItemSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListItemSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class ListItemSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListListSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListListSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class ListListSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListListSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListListSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.list
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class ListListSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListSuite.scala
@@ -9,7 +9,6 @@ import react.common.GenericComponentPACOps
 import react.common.GenericComponentPAOps
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class ListSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/list/ListSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/list/ListSuite.scala
@@ -9,7 +9,7 @@ import react.common.GenericComponentPACOps
 import react.common.GenericComponentPAOps
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class ListSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/loader/LoaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/loader/LoaderSuite.scala
@@ -9,7 +9,7 @@ import react.common.GenericComponentPACOps
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
 import react.semanticui.elements.label.Label
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class LoaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/loader/LoaderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/loader/LoaderSuite.scala
@@ -9,7 +9,6 @@ import react.common.GenericComponentPACOps
 import react.common.GenericFnComponentPACOps
 import react.common.syntax.vdom._
 import react.semanticui.elements.label.Label
-import react.semanticui.As.tagOf2AsC
 
 class LoaderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/placeholder/PlaceholderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/placeholder/PlaceholderSuite.scala
@@ -6,7 +6,7 @@ package react.semanticui.elements.placeholder
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.tagOf2AsC
+import react.semanticui.As.tagOf2AsC
 
 class PlaceholderSuite extends munit.FunSuite {
   test("render") {

--- a/semantic-ui/src/test/scala/react/semanticui/elements/placeholder/PlaceholderSuite.scala
+++ b/semantic-ui/src/test/scala/react/semanticui/elements/placeholder/PlaceholderSuite.scala
@@ -6,7 +6,6 @@ package react.semanticui.elements.placeholder
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.syntax.vdom._
-import react.semanticui.As.tagOf2AsC
 
 class PlaceholderSuite extends munit.FunSuite {
   test("render") {


### PR DESCRIPTION
- Reposition `tagOf2AsC` to enable `as = <.tag` without further imports.
- Move `content` as first parameter (only in `Header` and `LabelDetail` for the moment):
  In Scala 2 we were otherwise able to write `LabelDetail("hello")` which would invoke `LabelDetail.apply(modifiers: TagMod*)`. However, in Scala 3, the default `case class` constructor is called instead since it accepts a `String` as its first parameter, which was `as`. Therefore, invoking `LabelDetail("hello")` would result in the app attempting to render a `<hello>` tag.
  The way I find around this is to move the `content` parameter to first place. Usually when specifying other parameters we name them all, and when we only specify a single unnamed parameter we usually mean the `content` parameter.

I'm not sure it's worth keeping the `def apply(modifiers: TagMod*)` constructor around.

I only modified these 2 components for the moments in case anyone has objections or alternate ideas on how to approach this. Otherwise, we can migrate the rest of the components accepting `content` in a future PR.
  