### PR TITLE
Fix the regex in the prime-react/stImport rewrite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -510,7 +510,7 @@ lazy val primeReact = project
         val content     = IO.read(f)
         // use the ESM-style sources in imports
         val transformed = content.replaceAll(
-          """@JSImport\("primereact\/(.+?)[^\.][^e][^s][^m]",""",
+          """@JSImport\("primereact\/((.+?)(?<!\.esm))",""",
           """@JSImport("primereact/$1.esm","""
         )
         if (transformed != content)


### PR DESCRIPTION
One more fix for the regex used in the stImport rewrite for the JSImports in primereact.

The other regular expression `did` fail to match if the last 4 characters of the import were `.esm`. However, it also always excluded the last 4 characters of the import from the match group. It just so happened that I was looking at `Tag.scala` when I was checking to make sure additional `.esm` strings weren't appended to the import on each compile cycle. So,
`primereact/tag/tag` became `primereact/tag.esm` and didn't change with subsequent compiles. I didn't notice that one directory level had been dropped. But, `primereact/button/button` became `primereact/button/bu.esm`. 😆 

I switched the regex to use a negative lookbehind for the `.esm` and it seems to be working correctly now.