### PR TITLE
Expose some virtualized options in tables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.6"
+ThisBuild / tlBaseVersion       := "0.7"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/tanstack-table-demo/src/main/scala/react/table/demo/Table2.scala
+++ b/tanstack-table-demo/src/main/scala/react/table/demo/Table2.scala
@@ -38,7 +38,7 @@ object Table2:
             table,
             containerClass = Css("container"),
             rowClassFn = rowClassEvenOdd,
-            estimateSize = _ => 24
+            estimateRowHeightPx = _ => 24
           )
         )
       )

--- a/tanstack-table-demo/src/main/scala/react/table/demo/Table2.scala
+++ b/tanstack-table-demo/src/main/scala/react/table/demo/Table2.scala
@@ -37,7 +37,8 @@ object Table2:
           HTMLVirtualizedTable(
             table,
             containerClass = Css("container"),
-            rowClassFn = rowClassEvenOdd
+            rowClassFn = rowClassEvenOdd,
+            estimateSize = _ => 24
           )
         )
       )

--- a/tanstack-table-demo/src/main/scala/react/table/demo/Table3.scala
+++ b/tanstack-table-demo/src/main/scala/react/table/demo/Table3.scala
@@ -55,6 +55,6 @@ object Table3:
       .render((_, _, _, table) =>
         React.Fragment(
           <.h2("Table with Expanding Rows"),
-          HTMLVirtualizedTable(table, containerClass = Css("container"))
+          HTMLVirtualizedTable(table, containerClass = Css("container"), estimateSize = _ => 24)
         )
       )

--- a/tanstack-table-demo/src/main/scala/react/table/demo/Table3.scala
+++ b/tanstack-table-demo/src/main/scala/react/table/demo/Table3.scala
@@ -55,6 +55,10 @@ object Table3:
       .render((_, _, _, table) =>
         React.Fragment(
           <.h2("Table with Expanding Rows"),
-          HTMLVirtualizedTable(table, containerClass = Css("container"), estimateSize = _ => 24)
+          HTMLVirtualizedTable(
+            table,
+            containerClass = Css("container"),
+            estimateRowHeightPx = _ => 24
+          )
         )
       )

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
@@ -9,6 +9,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import react.common.*
 import react.common.style.Css
 import reactST.{tanstackTableCore => raw}
+import reactST.{tanstackVirtualCore => rawVirtual}
 
 import javax.swing.text.html.HTML
 
@@ -23,9 +24,14 @@ final case class HTMLTable[T](
 
 final case class HTMLVirtualizedTable[T](
   table:          raw.mod.Table[T],
+  estimateSize:   Int => Int,
+  // Table options
   containerClass: Css = Css.Empty,
   tableClass:     Css = Css.Empty,
-  rowClassFn:     (Int, T) => Css = (_, _: T) => Css.Empty
+  rowClassFn:     (Int, T) => Css = (_, _: T) => Css.Empty,
+  // Virtual options
+  overscan:       js.UndefOr[Int] = js.undefined,
+  getItemKey:     js.UndefOr[Int => rawVirtual.mod.Key] = js.undefined
 ) extends ReactFnProps(HTMLVirtualizedTable.component)
     with HTMLVirtualizedTableProps[T]
 

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
@@ -23,15 +23,15 @@ final case class HTMLTable[T](
     with HTMLTableProps[T]
 
 final case class HTMLVirtualizedTable[T](
-  table:          raw.mod.Table[T],
-  estimateSize:   Int => Int,
+  table:               raw.mod.Table[T],
+  estimateRowHeightPx: Int => Int,
   // Table options
-  containerClass: Css = Css.Empty,
-  tableClass:     Css = Css.Empty,
-  rowClassFn:     (Int, T) => Css = (_, _: T) => Css.Empty,
+  containerClass:      Css = Css.Empty,
+  tableClass:          Css = Css.Empty,
+  rowClassFn:          (Int, T) => Css = (_, _: T) => Css.Empty,
   // Virtual options
-  overscan:       js.UndefOr[Int] = js.undefined,
-  getItemKey:     js.UndefOr[Int => rawVirtual.mod.Key] = js.undefined
+  overscan:            js.UndefOr[Int] = js.undefined,
+  getItemKey:          js.UndefOr[Int => rawVirtual.mod.Key] = js.undefined
 ) extends ReactFnProps(HTMLVirtualizedTable.component)
     with HTMLVirtualizedTableProps[T]
 

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -204,7 +204,7 @@ object HTMLTableRenderer:
       .useVirtualizerBy((props, ref) =>
         VirtualOptions(
           count = props.table.getRowModel().rows.length,
-          estimateSize = props.estimateSize,
+          estimateSize = props.estimateRowHeightPx,
           getScrollElement = ref.get,
           overscan = props.overscan,
           getItemKey = props.getItemKey

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -204,9 +204,10 @@ object HTMLTableRenderer:
       .useVirtualizerBy((props, ref) =>
         VirtualOptions(
           count = props.table.getRowModel().rows.length,
-          estimateSize = _ => 24,
+          estimateSize = props.estimateSize,
           getScrollElement = ref.get,
-          overscan = 10
+          overscan = props.overscan,
+          getItemKey = props.getItemKey
         )
       )
       .render { (props, ref, virtualizer) =>

--- a/tanstack-table/src/main/scala/lucuma/react/table/props.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/props.scala
@@ -16,7 +16,7 @@ trait HTMLTableProps[T]:
 
 trait HTMLVirtualizedTableProps[T]:
   val table: raw.mod.Table[T]
-  val estimateSize: Int => Int
+  val estimateRowHeightPx: Int => Int
   // Table options
   val containerClass: Css
   val tableClass: Css

--- a/tanstack-table/src/main/scala/lucuma/react/table/props.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/props.scala
@@ -5,6 +5,9 @@ package lucuma.react.table
 
 import react.common.style.Css
 import reactST.{tanstackTableCore => raw}
+import reactST.{tanstackVirtualCore => rawVirtual}
+
+import scalajs.js
 
 trait HTMLTableProps[T]:
   val table: raw.mod.Table[T]
@@ -13,6 +16,11 @@ trait HTMLTableProps[T]:
 
 trait HTMLVirtualizedTableProps[T]:
   val table: raw.mod.Table[T]
+  val estimateSize: Int => Int
+  // Table options
   val containerClass: Css
   val tableClass: Css
   val rowClassFn: (Int, T) => Css
+  // Virtual options
+  val overscan: js.UndefOr[Int]
+  val getItemKey: js.UndefOr[Int => rawVirtual.mod.Key]


### PR DESCRIPTION
Exposes a few commonly used virtualized options in the new virtualized table. Forces clients to specify a row height estimate.