### PR TITLE
Add TabView/TabPanel primereact components

### DIFF
--- a/prime-react-demo/src/main/scala/react/table/demo/DemoComponents.scala
+++ b/prime-react-demo/src/main/scala/react/table/demo/DemoComponents.scala
@@ -41,6 +41,7 @@ object DemoComponents {
       .useState(false)                  // panel collapsed
       .useState(false)                  // sidebar
       .useState(SidebarOptions.default) // sidebar options
+      .useState(0)                      // tabview activeIndex
       .useState("Text to edit")         // for InputText
       .useState("Resizeable TextArea")  // for InputTextarea
       .useState(2)                      // for Dropdown
@@ -62,6 +63,7 @@ object DemoComponents {
           panelCollapsed,
           sidebar,
           sidebarOptions,
+          tabView,
           inputText,
           inputTextarea,
           dropdown,
@@ -299,6 +301,24 @@ object DemoComponents {
                     "Zydeco (/ˈzaɪdɪˌkoʊ/ ZY-dih-koh or /ˈzaɪdiˌkoʊ/ ZY-dee-koh, French: Zarico) is a music genre that evolved in southwest Louisiana by French Creole speakers which blends blues, rhythm and blues, and music indigenous to the Louisiana Creoles and the Native American people of Louisiana. Although it is distinct in origin from the Cajun music of Louisiana, the two forms influenced each other, forming a complex of genres native to the region. [From Wikipedia]"
                   ),
                   AccordionTab(header = "Weird Al")("Well, Weird Al. What else can we say?")
+                )
+              ),
+              TabView(
+                // I don't think you need to set `activeIndex` if you don't specify `onTabChange`
+                activeIndex = tabView.value,
+                onTabChange =
+                  idx => Callback.log(s"TabView onTabChange: $idx") >> tabView.setState(idx),
+                onTabClose = idx => Callback.log(s"TabView onTabClose: $idx")
+              )(
+                TabPanel(header = "Simple Header")("Simple Tab Contents"),
+                TabPanel(header = <.div(DemoStyles.HorizontalStack, "TagMod", <.small("Header")))(
+                  "Special Header Contents"
+                ),
+                TabPanel(header = "Closable Tab", leftIcon = "pi pi-bolt", closable = true)(
+                  "I'm not sure how useful Closable Tabs will be..."
+                ),
+                TabPanel(header = "Disabled Tab", disabled = true)(
+                  "You shouldn't be able to see this!"
                 )
               ),
               Panel(

--- a/prime-react/src/main/scala/react/primereact/TabPanel.scala
+++ b/prime-react/src/main/scala/react/primereact/TabPanel.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.primereact
+
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.facade.React.Node
+import japgolly.scalajs.react.vdom.TagMod
+import japgolly.scalajs.react.vdom.html_<^.*
+import react.common.*
+
+import scalajs.js.annotation.JSImport
+import scalajs.js
+
+case class TabPanel(
+  header:   js.UndefOr[VdomNode] = js.undefined,
+  disabled: js.UndefOr[Boolean] = js.undefined,
+  closable: js.UndefOr[Boolean] = js.undefined, // if tab can be removed. default: false
+  leftIcon: js.UndefOr[String] =
+    js.undefined, // left of header. Is applied as a CSS class (like primeicons)
+  rightIcon: js.UndefOr[String] =
+    js.undefined, // right of header. Is applied as a CSS class (like primeicons)
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  headerClass:            js.UndefOr[Css] = js.undefined,
+  contentClass:           js.UndefOr[Css] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericFnComponentPAC[TabPanel.TabPanelProps, TabPanel] {
+  override protected def cprops                     = TabPanel.props(this)
+  override protected val component                  = TabPanel.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+  def apply(mods: TagMod*)                          = addModifiers(mods)
+}
+
+object TabPanel {
+  @js.native
+  @JSImport("primereact/tabview/tabview.esm", "TabPanel")
+  object RawTabPanel extends js.Function1[js.Any, js.Any] {
+    def apply(i: js.Any): js.Any = js.native
+  }
+
+  @js.native
+  trait TabPanelProps extends js.Object {
+    var header: js.UndefOr[Node]             = js.native
+    var disabled: js.UndefOr[Boolean]        = js.native
+    var closable: js.UndefOr[Boolean]        = js.native
+    var leftIcon: js.UndefOr[String]         = js.native
+    var rightIcon: js.UndefOr[String]        = js.native
+    var className: js.UndefOr[String]        = js.native
+    var headerClassName: js.UndefOr[String]  = js.native
+    var contentClassName: js.UndefOr[String] = js.native
+  }
+
+  def props(q: TabPanel): TabPanelProps = {
+    val p = (new js.Object).asInstanceOf[TabPanelProps]
+    q.header.foreach(v => p.header = v.rawNode)
+    q.disabled.foreach(v => p.disabled = v)
+    q.closable.foreach(v => p.closable = v)
+    q.leftIcon.foreach(v => p.leftIcon = v)
+    q.rightIcon.foreach(v => p.rightIcon = v)
+    q.clazz.foreach(v => p.className = v.htmlClass)
+    q.headerClass.foreach(v => p.headerClassName = v.htmlClass)
+    q.contentClass.foreach(v => p.contentClassName = v.htmlClass)
+    p
+  }
+
+  private val component = JsFnComponent[TabPanelProps, Children.Varargs](RawTabPanel)
+}

--- a/prime-react/src/main/scala/react/primereact/TabView.scala
+++ b/prime-react/src/main/scala/react/primereact/TabView.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.primereact
+
+import cats.Id
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import react.common.*
+import reactST.primereact.components.{TabView => CTabView}
+import reactST.primereact.tabviewMod.TabViewTabChangeParams
+
+import scalajs.js
+
+// Note: You only need to specify activeIndex if you specify onTabChange, which then needs to set activeIndex
+// TODO: There are 2 events that are not in the ScalablyTyped facade: `onBeforeTabChange` and `onBeforeTabClose`
+// that allow for the prevention of changing or closing tabs, respectively. I could not immediately get these
+// to work with the `set` method, so I am delaying implementation until needed.
+// There is also supposed to be a `reset` function that I think restores closed tabs, but there is no
+// example in the documentation and I don't know how it would work in the React context.
+final case class TabView(
+  id:                  js.UndefOr[String] = js.undefined,
+  activeIndex:         js.UndefOr[Int] = js.undefined,
+  renderActiveOnly:    js.UndefOr[Boolean] = js.undefined, // default: true
+  scrollable:          js.UndefOr[Boolean] = js.undefined, // can scroll the tab headers? default: false
+  clazz:               js.UndefOr[Css] = js.undefined,
+  panelContainerClass: js.UndefOr[Css] = js.undefined,
+  onTabClose:          js.UndefOr[Int => Callback] = js.undefined,
+  onTabChange:         js.UndefOr[Int => Callback] = js.undefined,
+  panels:              List[TabPanel] = List.empty
+) extends ReactFnProps[TabView](TabView.component) {
+
+  def apply(panel: TabPanel, morePanels: TabPanel*): TabView =
+    copy(panels = (panels :+ panel) ++ morePanels)
+}
+
+object TabView {
+  private val component = ScalaFnComponent[TabView] { props =>
+    CTabView
+      .applyOrNot(props.id, _.id(_))
+      .applyOrNot(props.activeIndex, _.activeIndex(_))
+      .applyOrNot(props.renderActiveOnly, _.renderActiveOnly(_))
+      .applyOrNot(props.scrollable, _.scrollable(_))
+      .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
+      .applyOrNot(props.panelContainerClass, (c, p) => c.panelContainerClassName(p.htmlClass))
+      .applyOrNot(props.onTabClose, (c, p) => c.onTabClose(e => p(e.index.toInt)))
+      .applyOrNot(props.onTabChange, (c, p) => c.onTabChange(e => p(e.index.toInt)))(
+        props.panels.toTagMod
+      )
+  }
+}


### PR DESCRIPTION
There is still some un-facaded functionality for preventing changing/closing of tabs. These were not included in the ST facade for some reason. 

But, I think this covers everything Raul is using in Observe.