### PR TITLE
Force virtualized table rerender when number of rows changes

### DIFF
--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -16,6 +16,7 @@ import reactST.{tanstackTableCore => raw}
 import reactST.{tanstackVirtualCore => rawVirtual}
 
 import scala.util.Random
+
 import scalajs.js
 
 /**

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -13,7 +13,9 @@ import react.common.*
 import react.common.style.Css
 import reactST.{tanstackReactTable => rawReact}
 import reactST.{tanstackTableCore => raw}
+import reactST.{tanstackVirtualCore => rawVirtual}
 
+import scala.util.Random
 import scalajs.js
 
 /**
@@ -264,6 +266,8 @@ object HTMLTableRenderer:
       )
     )
 
+  private val random = new Random()
+
   def componentBuilderVirtualized[T, Props <: HTMLVirtualizedTableProps[_]](
     renderer: HTMLTableRenderer[T]
   ) =
@@ -284,12 +288,22 @@ object HTMLTableRenderer:
       .useEffectOnMountBy((props, _, virtualizer) => // Allow external access to Virtualizer
         props.virtualizerRef.toOption.map(_.set(virtualizer.some)).getOrEmpty
       )
-      .render { (props, ref, virtualizer) =>
+      // The virtualizer seems to get confused when we change the number of rendered rows.
+      // Therefore, we use a key to force a remount when the number of rows changes.
+      .useMemoBy((props, _, _) => props.table.getRowModel().rows.length)((_, _, _) =>
+        _ => random.nextInt()
+      )
+      .render { (props, ref, virtualizer, rowsRandom) =>
         val rows                        = props.table.getRowModel().rows
-        val (paddingTop, paddingBottom) = virtualVerticalPadding(virtualizer)
+        val (paddingTop, paddingBottom) =
+          virtualVerticalPadding(virtualizer, props.debugVirtualizer)
 
         // TODO Should we attempt to make the <table>  the container (scroll element) and <tbody> the virtualized element?
-        <.div.withRef(ref)(^.overflowY.auto, props.containerMod)(
+        <.div.withRef(ref)(
+          ^.overflowY.auto,
+          props.containerMod,
+          ^.key := s"table-${rowsRandom.value}"
+        )(
           renderer.render(
             props.table,
             virtualizer.getVirtualItems().map(virtualItem => rows(virtualItem.index.toInt)),
@@ -323,15 +337,24 @@ object HTMLTableRenderer:
           getScrollElement = ref.get,
           overscan = props.overscan,
           getItemKey = props.getItemKey,
-          onChange = props.onChange
+          onChange = props.onChange,
+          debug = props.debugVirtualizer
         )
       )
       .useEffectOnMountBy((props, _, virtualizer) => // Allow external access to Virtualizer
         props.virtualizerRef.toOption.map(_.set(virtualizer.some)).getOrEmpty
       )
-      .render { (props, ref, virtualizer) =>
+      // The virtualizer seems to get confused when we change the number of rendered rows.
+      // Therefore, we use a key to force a remount when the number of rows changes.
+      .useMemoBy((props, _, _) => props.table.getRowModel().rows.length)((_, _, _) =>
+        _ => random.nextInt()
+      )
+      .render { (props, ref, virtualizer, rowsRandom) =>
         val rows                        = props.table.getRowModel().rows
-        val (paddingTop, paddingBottom) = virtualVerticalPadding(virtualizer)
+        // This is artificially added space on top and bottom so that the scroll bar is shown as if there were
+        // the right number of elements on either side.
+        val (paddingTop, paddingBottom) =
+          virtualVerticalPadding(virtualizer, props.debugVirtualizer)
 
         // We use this trick to get a component whose height adjusts to the container.
         // See https://stackoverflow.com/a/1230666
@@ -342,7 +365,8 @@ object HTMLTableRenderer:
           ^.position.relative,
           ^.height := "100%",
           ^.overflow.auto,
-          props.containerMod
+          props.containerMod,
+          ^.key    := s"table-${rowsRandom.value}"
         )(
           <.div(
             ^.position.absolute,

--- a/tanstack-table/src/main/scala/lucuma/react/virtual/package.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/virtual/package.scala
@@ -5,13 +5,14 @@ package lucuma.react
 
 import japgolly.scalajs.react.vdom.TagMod
 import lucuma.react.virtual.facade.Virtualizer
-import org.scalajs.dom.Element
+import org.scalajs.dom
 
 import scalajs.js
 
 package object virtual extends HooksApiExt:
-  def virtualVerticalPadding[TScrollElement <: Element, TItemElement <: Element](
-    virtualizer: Virtualizer[TScrollElement, TItemElement]
+  def virtualVerticalPadding[TScrollElement <: dom.Element, TItemElement <: dom.Element](
+    virtualizer: Virtualizer[TScrollElement, TItemElement],
+    debug:       js.UndefOr[Boolean]
   ): (Int, Int) =
     val virtualRows   = virtualizer.getVirtualItems()
     val totalSize     = virtualizer.getTotalSize().toInt
@@ -21,5 +22,14 @@ package object virtual extends HooksApiExt:
       if (virtualRows.length > 0)
         totalSize - virtualRows.lastOption.map(_.end.toInt).getOrElse(0)
       else 0
+
+    if (debug.contains(true))
+      dom.console.log(
+        "Measuring Virtualizer Padding:",
+        s"Virtual Rows: ${virtualRows.size},",
+        s"Total Size: ${totalSize}px,",
+        s"HeadOption Start: ${virtualRows.headOption.map(_.start.toInt)}px,",
+        s"LastOption End: ${virtualRows.lastOption.map(_.end.toInt)}px"
+      )
 
     (paddingTop, paddingBottom)


### PR DESCRIPTION
This PR fixes the issue described in https://app.shortcut.com/lucuma/story/1771/configuration-table-misbehavior#activity-1781.

Virtualized tables render a dummy padding in order to trick the scrollbar into thinking there are more rows. This padding is always outside of the range seen by the user.

However, the new virtualizer seems to get confused in some cases when the number of rows changes on the fly and renders less rows than it should. This resulted not only in missing rows but the padding being shown. We are using a beta version of the virtualizer after all.

This PR attempts to fix this by using a key in the virtualized table that changes when the number of rows change. This forces a rerender if the number of rows change and avoids the bug.

Additionally, it adds some debug info if `debugVirtualizer` is set to `true`.