### PR TITLE
More additions to table facade

### DIFF
--- a/beautiful-dnd/yarn.lock
+++ b/beautiful-dnd/yarn.lock
@@ -547,7 +547,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.22"
+ThisBuild / tlBaseVersion       := "0.23"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/circular-progressbar/yarn.lock
+++ b/circular-progressbar/yarn.lock
@@ -499,7 +499,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/clipboard/yarn.lock
+++ b/clipboard/yarn.lock
@@ -547,7 +547,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/datepicker/yarn.lock
+++ b/datepicker/yarn.lock
@@ -547,7 +547,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/draggable/yarn.lock
+++ b/draggable/yarn.lock
@@ -547,7 +547,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/floatingui/yarn.lock
+++ b/floatingui/yarn.lock
@@ -453,7 +453,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/grid-layout/yarn.lock
+++ b/grid-layout/yarn.lock
@@ -547,7 +547,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/highcharts/yarn.lock
+++ b/highcharts/yarn.lock
@@ -491,7 +491,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/hotkeys/yarn.lock
+++ b/hotkeys/yarn.lock
@@ -521,7 +521,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/moon/yarn.lock
+++ b/moon/yarn.lock
@@ -499,7 +499,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@atlaskit/tree": "^8.6.3",
     "@cquiroz/react-moon": "^2.0.2",
     "@floating-ui/react-dom-interactions": "^0.10.3",
-    "@tanstack/react-table": "^8.7.0",
+    "@tanstack/react-table": "^8.5.22",
     "@tanstack/react-virtual": "v3.0.0-beta.22",
     "@vitejs/plugin-react": "^2.2.0",
     "copy-to-clipboard": "^3.3.3",

--- a/prime-react/yarn.lock
+++ b/prime-react/yarn.lock
@@ -491,7 +491,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/resizable/yarn.lock
+++ b/resizable/yarn.lock
@@ -521,7 +521,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/semantic-ui/yarn.lock
+++ b/semantic-ui/yarn.lock
@@ -540,7 +540,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/tanstack-table/package.json
+++ b/tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@tanstack/react-table": "^8.5.22",
-    "@tanstack/react-virtual": "v3.0.0-beta.21"
+    "@tanstack/react-virtual": "v3.0.0-beta.22"
   }
 }

--- a/tanstack-table/src/main/scala/lucuma/react/SizePx.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/SizePx.scala
@@ -3,7 +3,11 @@
 
 package lucuma.react
 
+import cats.Endo
+
 opaque type SizePx = Int
 object SizePx:
-  inline def apply(value: Int): SizePx                  = value
-  extension (opaqueValue: SizePx) inline def value: Int = opaqueValue
+  inline def apply(value: Int): SizePx = value
+  extension (opaqueValue: SizePx)
+    inline def value: Int = opaqueValue
+    inline def modify(f: Endo[Int]): SizePx = f(opaqueValue)

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
@@ -7,6 +7,7 @@ import cats.syntax.all.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.SizePx
+import org.scalajs.dom.HTMLDivElement
 import react.common.*
 import react.common.style.Css
 import reactST.{tanstackTableCore => raw}
@@ -39,6 +40,7 @@ final case class HTMLVirtualizedTable[T](
   estimateSize:     Int => SizePx,
   // Table options
   containerMod:     TagMod = TagMod.empty,
+  containerRef:     js.UndefOr[Ref.Simple[HTMLDivElement]] = js.undefined,
   tableMod:         TagMod = TagMod.empty,
   headerMod:        TagMod = TagMod.empty,
   headerRowMod:     raw.mod.CoreHeaderGroup[T] => TagMod = (_: raw.mod.CoreHeaderGroup[T]) =>
@@ -66,6 +68,7 @@ final case class HTMLAutoHeightVirtualizedTable[T](
   estimateSize:      Int => SizePx,
   // Table options
   containerMod:      TagMod = TagMod.empty,
+  containerRef:      js.UndefOr[Ref.Simple[HTMLDivElement]] = js.undefined,
   innerContainerMod: TagMod = TagMod.empty,
   tableMod:          TagMod = TagMod.empty,
   headerMod:         TagMod = TagMod.empty,

--- a/tanstack-table/src/main/scala/lucuma/react/table/PartialTableState.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/PartialTableState.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.table
+
+import org.scalablytyped.runtime.StringDictionary
+import reactST.{tanstackTableCore => raw}
+
+import scalajs.js
+import scalajs.js.JSConverters.*
+
+// Still missing (everywhere): filters, grouping, pagination
+case class PartialTableState(private[table] val toJs: raw.anon.PartialTableState):
+  lazy val columnVisibility: Option[ColumnVisibility] =
+    toJs.columnVisibility.toOption.map(ColumnVisibility.fromJs)
+
+  /** WARNING: This mutates the object in-place. */
+  def setColumnVisibility(columnVisibility: Option[ColumnVisibility]): PartialTableState =
+    PartialTableState(
+      columnVisibility.fold(toJs.setColumnVisibilityUndefined)(v =>
+        toJs.setColumnVisibility(v.toJs)
+      )
+    )
+
+  lazy val columnOrder: Option[ColumnOrder] =
+    toJs.columnOrder.toOption.map(ColumnOrder.fromJs)
+
+  /** WARNING: This mutates the object in-place. */
+  def setColumnOrder(columnOrder: Option[ColumnOrder]): PartialTableState =
+    PartialTableState(
+      columnOrder.fold(toJs.setColumnOrderUndefined)(v => toJs.setColumnOrder(v.toJs))
+    )
+
+  lazy val columnPinning: Option[ColumnPinning] =
+    toJs.columnPinning.toOption.map(ColumnPinning.fromJs)
+
+  lazy val sorting: Option[Sorting] =
+    toJs.sorting.toOption.map(Sorting.fromJs)
+
+  /** WARNING: This mutates the object in-place. */
+  def setSorting(sorting: Option[Sorting]): PartialTableState =
+    PartialTableState(
+      sorting.fold(toJs.setSortingUndefined)(v => toJs.setSorting(v.toJs))
+    )
+
+  lazy val expanded: Option[Expanded] =
+    toJs.expanded.toOption.map(Expanded.fromJs)
+
+  /** WARNING: This mutates the object in-place. */
+  def setExpanded(expanded: Option[Expanded]): PartialTableState =
+    PartialTableState(
+      expanded.fold(toJs.setExpandedUndefined)(v => toJs.setExpanded(v.toJs))
+    )
+
+  lazy val columnSizing: Option[ColumnSizing] =
+    toJs.columnSizing.toOption.map(ColumnSizing.fromJs)
+
+  /** WARNING: This mutates the object in-place. */
+  def setColumnSizing(columnSizing: Option[ColumnSizing]): PartialTableState =
+    PartialTableState(
+      columnSizing.fold(toJs.setColumnSizingUndefined)(v => toJs.setColumnSizing(v.toJs))
+    )
+
+  lazy val columnSizingInfo: Option[ColumnSizingInfo] =
+    toJs.columnSizingInfo.toOption.map(ColumnSizingInfo.fromJs)
+
+  /** WARNING: This mutates the object in-place. */
+  def setColumnSizingInfo(columnSizingInfo: Option[ColumnSizingInfo]): PartialTableState =
+    PartialTableState(
+      columnSizingInfo.fold(toJs.setColumnSizingInfoUndefined)(v =>
+        toJs.setColumnSizingInfo(v.toJs)
+      )
+    )
+
+  lazy val rowSelection: Option[RowSelection] =
+    toJs.rowSelection.toOption.map(RowSelection.fromJs)
+
+  /** WARNING: This mutates the object in-place. */
+  def setRowSelection(rowSelection: Option[RowSelection]): PartialTableState =
+    PartialTableState(
+      rowSelection.fold(toJs.setRowSelectionUndefined)(v => toJs.setRowSelection(v.toJs))
+    )
+
+object PartialTableState:
+  def apply(
+    columnVisibility: js.UndefOr[ColumnVisibility] = js.undefined,
+    columnOrder:      js.UndefOr[ColumnOrder] = js.undefined,
+    columnPinning:    js.UndefOr[ColumnPinning] = js.undefined,
+    sorting:          js.UndefOr[Sorting] = js.undefined,
+    expanded:         js.UndefOr[Expanded] = js.undefined,
+    columnSizing:     js.UndefOr[ColumnSizing] = js.undefined,
+    columnSizingInfo: js.UndefOr[ColumnSizingInfo] = js.undefined,
+    rowSelection:     js.UndefOr[RowSelection] = js.undefined
+  ): PartialTableState = PartialTableState(
+    raw.anon
+      .PartialTableState()
+      .applyOrNot(columnVisibility, (s, p) => s.setColumnVisibility(p.toJs))
+      .applyOrNot(columnOrder, (s, p) => s.setColumnOrder(p.toJs))
+      .applyOrNot(columnPinning, (s, p) => s.setColumnPinning(p.toJs))
+      .applyOrNot(sorting, (s, p) => s.setSorting(p.toJs))
+      .applyOrNot(expanded, (s, p) => s.setExpanded(p.toJs))
+      .applyOrNot(columnSizing, (s, p) => s.setColumnSizing(p.toJs))
+      .applyOrNot(columnSizingInfo, (s, p) => s.setColumnSizingInfo(p.toJs))
+      .applyOrNot(rowSelection, (s, p) => s.setRowSelection(p.toJs))
+  )

--- a/tanstack-table/src/main/scala/lucuma/react/table/facade/TableOptionsJS.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/facade/TableOptionsJS.scala
@@ -14,15 +14,18 @@ trait TableOptionsJs[T] extends js.Object:
   var data: js.Array[T]
   var getCoreRowModel: js.Function1[raw.mod.Table[T], js.Function0[raw.mod.RowModel[T]]]
 
-  var getRowId: js.UndefOr[js.Function3[T, Int, js.UndefOr[T], String]]          = js.undefined
-  var onStateChange: js.UndefOr[raw.mod.Updater[raw.mod.TableState] => Callback] = js.undefined
-  var renderFallbackValue: js.UndefOr[Any]                                       = js.undefined
-  var state: js.UndefOr[raw.anon.PartialTableState]                              = js.undefined
-  var initialState: js.UndefOr[raw.mod.InitialTableState]                        = js.undefined
+  var getRowId: js.UndefOr[js.Function3[T, Int, js.UndefOr[T], String]] = js.undefined
+  var onStateChange: js.UndefOr[raw.mod.OnChangeFn[raw.mod.TableState]] = js.undefined
+  var renderFallbackValue: js.UndefOr[Any]                              = js.undefined
+  var state: js.UndefOr[raw.anon.PartialTableState]                     = js.undefined
+  var initialState: js.UndefOr[raw.mod.InitialTableState]               = js.undefined
 
   // Column Sizing // TODO Rest of the properties
-  var enableColumnResizing: js.UndefOr[Boolean]              = js.undefined
-  var columnResizeMode: js.UndefOr[raw.mod.ColumnResizeMode] = js.undefined
+  var enableColumnResizing: js.UndefOr[Boolean]                                               = js.undefined
+  var columnResizeMode: js.UndefOr[raw.mod.ColumnResizeMode]                                  = js.undefined
+  var onColumnSizingChange: js.UndefOr[raw.mod.OnChangeFn[raw.mod.ColumnSizingState]]         = js.undefined
+  var onColumnSizingInfoChange: js.UndefOr[raw.mod.OnChangeFn[raw.mod.ColumnSizingInfoState]] =
+    js.undefined
 
   // Column Visibility
   var enableHiding: js.UndefOr[Boolean]                                                 = js.undefined

--- a/tanstack-table/src/main/scala/lucuma/react/table/props.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/props.scala
@@ -4,6 +4,7 @@
 package lucuma.react.table
 
 import japgolly.scalajs.react.NonEmptyRef
+import japgolly.scalajs.react.Ref
 import japgolly.scalajs.react.callback.Callback
 import japgolly.scalajs.react.vdom.TagMod
 import japgolly.scalajs.react.vdom.VdomNode
@@ -40,6 +41,7 @@ trait HTMLVirtualizedTableProps[T] extends HTMLTableProps[T]:
   def estimateSize: Int => SizePx
   // Table options
   def containerMod: TagMod
+  def containerRef: js.UndefOr[Ref.Simple[HTMLDivElement]]
   // Virtual options
   def overscan: js.UndefOr[Int]
   def getItemKey: js.UndefOr[Int => rawVirtual.mod.Key]

--- a/tanstack-table/yarn.lock
+++ b/tanstack-table/yarn.lock
@@ -416,22 +416,22 @@
   dependencies:
     "@tanstack/table-core" "8.5.22"
 
-"@tanstack/react-virtual@v3.0.0-beta.21":
-  version "3.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.21.tgz#ad1a619aa57f5a150169fd7f39f1f79fe6b70645"
-  integrity sha512-GVLzOK/AX0ddGLeMlTaZBpqXeNcqhp7VUlMm+9ef5ecHLEwFR1vl5PISgIeUyrsipTOMoq1JP/U61sZeCgyjkw==
+"@tanstack/react-virtual@v3.0.0-beta.22":
+  version "3.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.22.tgz#bd772d08162e9aa77ed46329dace348fcfaac225"
+  integrity sha512-OPgnjp6+F/8twCToWq1bglbxaNoOIKac/K6zhljhGIVq5lp1VXpkw47lWvLTU7RFfcFl03E61zZkqGbSFTk9uA==
   dependencies:
-    "@tanstack/virtual-core" "3.0.0-beta.21"
+    "@tanstack/virtual-core" "3.0.0-beta.22"
 
 "@tanstack/table-core@8.5.22":
   version "8.5.22"
   resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.5.22.tgz#ba381db5f7f47558aba6e75cc94ee32a691defeb"
   integrity sha512-D3wDbVXl3Bi5PdGfle6DijhLzZxrvMyZsE1dSHH0xBsqEbu7Pkxn5EEd6CA9tGsCgXIEP1s4Yfy1cZ9xnMz1sQ==
 
-"@tanstack/virtual-core@3.0.0-beta.21":
-  version "3.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.21.tgz#e4d826aaf5ab1741c4fe5348ea2eacadc5eff84b"
-  integrity sha512-knThjuCrDlTAd9xvYnl+RhYMbJ7N/lYYE5V02KASgWmofBZO5sHPoTV74926JEOHzZZ7yZzotNYzG51kA3hjoQ==
+"@tanstack/virtual-core@3.0.0-beta.22":
+  version "3.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.22.tgz#1c3c4723fa67492af6a35100b4c8818d6c4d7c58"
+  integrity sha512-kMpEeXXxHXP3mmXmMwKJvCzsiGGRDK745EsOYCiBP9hER04kyPk89rOQIvXhIFBkSj+TjSNCovIIhEzqkpIDNw==
 
 "@tootallnate/once@2":
   version "2.0.0"

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -547,7 +547,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/tree/yarn.lock
+++ b/tree/yarn.lock
@@ -547,7 +547,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,7 +445,7 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@tanstack/react-table@^8.7.0":
+"@tanstack/react-table@^8.5.22":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.0.tgz#853fae74db6bf49738d0f18e4d507b00262fc09c"
   integrity sha512-VJ+9rsymDLaSU35rWOfX0bwNXnpW1i+T14wi+sHx8lxwAsfg6IY1Yw7FPfGADvUFP5eQn2t4nlohAJd+IoEj/Q==


### PR DESCRIPTION
- Ability to keep (partial) table state externally.
- Ability to pass our own ref to the virtualized container. Useful if we use other functionality on the same `div`, like `resizeDetector`.
- Scala-idiomatic API on `TableOptions`.