### PR TITLE
Add tooltips to more primereact components

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.25"
+ThisBuild / tlBaseVersion       := "0.26"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/prime-react-demo/src/main/scala/react/table/demo/DemoControlsPanel.scala
+++ b/prime-react-demo/src/main/scala/react/table/demo/DemoControlsPanel.scala
@@ -116,7 +116,11 @@ object DemoControlsPanel {
                             rows = 6,
                             onChange = e => inputTextarea.setState(e.target.value),
                             clazz = DemoStyles.FormField
-              ).withMods(mouseEntered("InputTextarea")),
+              ).withMods(mouseEntered("InputTextarea"),
+                         ^.onFocus ==> { (e: ReactFocusEventFromInput) =>
+                           Callback.log(s"Focused TextArea: ${e.target.value}")
+                         }
+              ),
               <.label("Dropdown", ^.htmlFor          := "dropdown", DemoStyles.FormFieldLabel),
               Dropdown(
                 id = "dropdown",
@@ -228,10 +232,6 @@ object DemoControlsPanel {
                   if (si.disabled.getOrElse(false)) <.s(si.label.toOption)
                   else <.span(si.label.toOption)
               )(mouseEntered("SelectButtonMultiple")),
-              <.label("ProgressBar 1",
-                      ^.htmlFor                      := "progress-indeterminate",
-                      DemoStyles.FormFieldLabel
-              ),
               <.label("ToggleButton", DemoStyles.FormFieldLabel),
               <.span(DemoStyles.FormField)(
                 ToggleButton(
@@ -243,6 +243,10 @@ object DemoControlsPanel {
                   checked = toggleButton.value,
                   onChange = toggleButton.setState
                 )
+              ),
+              <.label("ProgressBar 1",
+                      ^.htmlFor                      := "progress-indeterminate",
+                      DemoStyles.FormFieldLabel
               ),
               ProgressBar(id = "progress-indeterminate", mode = ProgressBar.Mode.Indeterminate),
               <.div(

--- a/prime-react/src/main/scala/react/primereact/Checkbox.scala
+++ b/prime-react/src/main/scala/react/primereact/Checkbox.scala
@@ -7,17 +7,20 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import react.common.*
 import reactST.primereact.components.{Checkbox => CCheckbox}
+import reactST.primereact.tooltipTooltipoptionsMod.{TooltipOptions => CTooltipOptions}
 
 import scalajs.js
 
 case class Checkbox(
-  id:        js.UndefOr[String] = js.undefined,
-  inputId:   js.UndefOr[String] = js.undefined,  // id of the input element
-  checked:   js.UndefOr[Boolean] = js.undefined, // id of the input element
-  disabled:  js.UndefOr[Boolean] = js.undefined,
-  clazz:     js.UndefOr[Css] = js.undefined,
-  onChange:  js.UndefOr[Boolean => Callback] = js.undefined,
-  modifiers: Seq[TagMod] = Seq.empty
+  id:             js.UndefOr[String] = js.undefined,
+  inputId:        js.UndefOr[String] = js.undefined,  // id of the input element
+  checked:        js.UndefOr[Boolean] = js.undefined, // id of the input element
+  disabled:       js.UndefOr[Boolean] = js.undefined,
+  clazz:          js.UndefOr[Css] = js.undefined,
+  tooltip:        js.UndefOr[String] = js.undefined,
+  tooltipOptions: js.UndefOr[TooltipOptions] = js.undefined,
+  onChange:       js.UndefOr[Boolean => Callback] = js.undefined,
+  modifiers:      Seq[TagMod] = Seq.empty
 ) extends ReactFnProps[Checkbox](Checkbox.component) {
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
@@ -32,6 +35,8 @@ object Checkbox {
       .applyOrNot(props.checked, _.checked(_))
       .applyOrNot(props.disabled, _.disabled(_))
       .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
+      .applyOrNot(props.tooltip, _.tooltip(_))
+      .applyOrNot(props.tooltipOptions, (c, p) => c.tooltipOptions(p.asInstanceOf[CTooltipOptions]))
       .applyOrNot(props.onChange, (c, p) => c.onChange(iwcp => p(iwcp.checked)))(
         props.modifiers.toTagMod
       )

--- a/prime-react/src/main/scala/react/primereact/Checkbox.scala
+++ b/prime-react/src/main/scala/react/primereact/Checkbox.scala
@@ -13,8 +13,8 @@ import scalajs.js
 
 case class Checkbox(
   id:             js.UndefOr[String] = js.undefined,
-  inputId:        js.UndefOr[String] = js.undefined,  // id of the input element
-  checked:        js.UndefOr[Boolean] = js.undefined, // id of the input element
+  inputId:        js.UndefOr[String] = js.undefined, // id of the input element
+  checked:        js.UndefOr[Boolean] = js.undefined,
   disabled:       js.UndefOr[Boolean] = js.undefined,
   clazz:          js.UndefOr[Css] = js.undefined,
   tooltip:        js.UndefOr[String] = js.undefined,

--- a/prime-react/src/main/scala/react/primereact/Dropdown.scala
+++ b/prime-react/src/main/scala/react/primereact/Dropdown.scala
@@ -18,12 +18,16 @@ case class Dropdown[A](
   options:         List[SelectItem[A]],
   id:              js.UndefOr[String] = js.undefined,
   clazz:           js.UndefOr[Css] = js.undefined,
+  panelClass:      js.UndefOr[Css] = js.undefined,
   filter:          js.UndefOr[Boolean] = js.undefined,
   showFilterClear: js.UndefOr[Boolean] = js.undefined,
   placeholder:     js.UndefOr[String] = js.undefined,
   disabled:        js.UndefOr[Boolean] = js.undefined,
   dropdownIcon:    js.UndefOr[String] = js.undefined,
+  tooltip:         js.UndefOr[String] = js.undefined,
+  tooltipOptions:  js.UndefOr[TooltipOptions] = js.undefined,
   onChange:        js.UndefOr[A => Callback] = js.undefined,
+  onChangeE:       js.UndefOr[ReactEvent => Callback] = js.undefined, // called after onChange
   modifiers:       Seq[TagMod] = Seq.empty
 )(using val eqAA:  Eq[A])
     extends ReactFnProps[DropdownBase](DropdownBase.component)

--- a/prime-react/src/main/scala/react/primereact/Dropdown.scala
+++ b/prime-react/src/main/scala/react/primereact/Dropdown.scala
@@ -27,7 +27,7 @@ case class Dropdown[A](
   tooltip:         js.UndefOr[String] = js.undefined,
   tooltipOptions:  js.UndefOr[TooltipOptions] = js.undefined,
   onChange:        js.UndefOr[A => Callback] = js.undefined,
-  onChangeE:       js.UndefOr[ReactEvent => Callback] = js.undefined, // called after onChange
+  onChangeE:       js.UndefOr[(A, ReactEvent) => Callback] = js.undefined, // called after onChange
   modifiers:       Seq[TagMod] = Seq.empty
 )(using val eqAA:  Eq[A])
     extends ReactFnProps[DropdownBase](DropdownBase.component)

--- a/prime-react/src/main/scala/react/primereact/DropdownBase.scala
+++ b/prime-react/src/main/scala/react/primereact/DropdownBase.scala
@@ -36,7 +36,7 @@ private[primereact] trait DropdownBase {
   val tooltip: js.UndefOr[String]
   val tooltipOptions: js.UndefOr[TooltipOptions]
   val onChange: js.UndefOr[GG[AA] => Callback]
-  val onChangeE: js.UndefOr[ReactEvent => Callback] // called after onChange
+  val onChangeE: js.UndefOr[(GG[AA], ReactEvent) => Callback] // called after onChange
   val modifiers: Seq[TagMod]
 
   protected def getter: js.UndefOr[Int]
@@ -49,8 +49,9 @@ object DropdownBase {
   private[primereact] val component = ScalaFnComponent[DropdownBase] { props =>
     val changeHandler: DropdownChangeParams => Callback =
       parms =>
-        props.onChange.toOption.map(_(props.finder(parms.value))).getOrElse(Callback.empty) >>
-          props.onChangeE.toOption.map(_(parms.originalEvent)).getOrElse(Callback.empty)
+        val a = props.finder(parms.value)
+        props.onChange.toOption.map(_(a)).getOrElse(Callback.empty) >>
+          props.onChangeE.toOption.map(_(a, parms.originalEvent)).getOrElse(Callback.empty)
 
     CDropdown
       .value(props.getter)

--- a/prime-react/src/main/scala/react/primereact/DropdownOptional.scala
+++ b/prime-react/src/main/scala/react/primereact/DropdownOptional.scala
@@ -17,13 +17,17 @@ case class DropdownOptional[A](
   options:         List[SelectItem[A]],
   id:              js.UndefOr[String] = js.undefined,
   clazz:           js.UndefOr[Css] = js.undefined,
+  panelClass:      js.UndefOr[Css] = js.undefined,
   showClear:       js.UndefOr[Boolean] = js.undefined,
   filter:          js.UndefOr[Boolean] = js.undefined,
   showFilterClear: js.UndefOr[Boolean] = js.undefined,
   placeholder:     js.UndefOr[String] = js.undefined,
   disabled:        js.UndefOr[Boolean] = js.undefined,
   dropdownIcon:    js.UndefOr[String] = js.undefined,
+  tooltip:         js.UndefOr[String] = js.undefined,
+  tooltipOptions:  js.UndefOr[TooltipOptions] = js.undefined,
   onChange:        js.UndefOr[Option[A] => Callback] = js.undefined,
+  onChangeE:       js.UndefOr[ReactEvent => Callback] = js.undefined, // called after onChange
   modifiers:       Seq[TagMod] = Seq.empty
 )(using val eqAA:  Eq[A])
     extends ReactFnProps[DropdownBase](DropdownBase.component)

--- a/prime-react/src/main/scala/react/primereact/DropdownOptional.scala
+++ b/prime-react/src/main/scala/react/primereact/DropdownOptional.scala
@@ -27,9 +27,10 @@ case class DropdownOptional[A](
   tooltip:         js.UndefOr[String] = js.undefined,
   tooltipOptions:  js.UndefOr[TooltipOptions] = js.undefined,
   onChange:        js.UndefOr[Option[A] => Callback] = js.undefined,
-  onChangeE:       js.UndefOr[ReactEvent => Callback] = js.undefined, // called after onChange
-  modifiers:       Seq[TagMod] = Seq.empty
-)(using val eqAA:  Eq[A])
+  onChangeE:       js.UndefOr[(Option[A], ReactEvent) => Callback] =
+    js.undefined, // called after onChange
+  modifiers:      Seq[TagMod] = Seq.empty
+)(using val eqAA: Eq[A])
     extends ReactFnProps[DropdownBase](DropdownBase.component)
     with DropdownBase {
   type AA    = A

--- a/prime-react/src/main/scala/react/primereact/InputSwitch.scala
+++ b/prime-react/src/main/scala/react/primereact/InputSwitch.scala
@@ -13,8 +13,8 @@ import scalajs.js
 
 case class InputSwitch(
   id:             js.UndefOr[String] = js.undefined,
-  inputId:        js.UndefOr[String] = js.undefined,  // id of the input element
-  checked:        js.UndefOr[Boolean] = js.undefined, // id of the input element
+  inputId:        js.UndefOr[String] = js.undefined, // id of the input element
+  checked:        js.UndefOr[Boolean] = js.undefined,
   disabled:       js.UndefOr[Boolean] = js.undefined,
   clazz:          js.UndefOr[Css] = js.undefined,
   tooltip:        js.UndefOr[String] = js.undefined,

--- a/prime-react/src/main/scala/react/primereact/InputSwitch.scala
+++ b/prime-react/src/main/scala/react/primereact/InputSwitch.scala
@@ -7,17 +7,20 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import react.common.*
 import reactST.primereact.components.{InputSwitch => CInputSwitch}
+import reactST.primereact.tooltipTooltipoptionsMod.{TooltipOptions => CTooltipOptions}
 
 import scalajs.js
 
 case class InputSwitch(
-  id:        js.UndefOr[String] = js.undefined,
-  inputId:   js.UndefOr[String] = js.undefined,  // id of the input element
-  checked:   js.UndefOr[Boolean] = js.undefined, // id of the input element
-  disabled:  js.UndefOr[Boolean] = js.undefined,
-  clazz:     js.UndefOr[Css] = js.undefined,
-  onChange:  js.UndefOr[Boolean => Callback] = js.undefined,
-  modifiers: Seq[TagMod] = Seq.empty
+  id:             js.UndefOr[String] = js.undefined,
+  inputId:        js.UndefOr[String] = js.undefined,  // id of the input element
+  checked:        js.UndefOr[Boolean] = js.undefined, // id of the input element
+  disabled:       js.UndefOr[Boolean] = js.undefined,
+  clazz:          js.UndefOr[Css] = js.undefined,
+  tooltip:        js.UndefOr[String] = js.undefined,
+  tooltipOptions: js.UndefOr[TooltipOptions] = js.undefined,
+  onChange:       js.UndefOr[Boolean => Callback] = js.undefined,
+  modifiers:      Seq[TagMod] = Seq.empty
 ) extends ReactFnProps[InputSwitch](InputSwitch.component) {
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
@@ -32,6 +35,8 @@ object InputSwitch {
       .applyOrNot(props.checked, _.checked(_))
       .applyOrNot(props.disabled, _.disabled(_))
       .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
+      .applyOrNot(props.tooltip, _.tooltip(_))
+      .applyOrNot(props.tooltipOptions, (c, p) => c.tooltipOptions(p.asInstanceOf[CTooltipOptions]))
       .applyOrNot(props.onChange, (c, p) => c.onChange(iwcp => p(iwcp.value)))(
         props.modifiers.toTagMod
       )

--- a/prime-react/src/main/scala/react/primereact/InputText.scala
+++ b/prime-react/src/main/scala/react/primereact/InputText.scala
@@ -7,20 +7,23 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import react.common.*
 import reactST.primereact.components.{InputText => CInputText}
+import reactST.primereact.tooltipTooltipoptionsMod.{TooltipOptions => CTooltipOptions}
 
 import scalajs.js
 
 case class InputText(
-  id:          String,
-  clazz:       js.UndefOr[Css] = js.undefined,
-  value:       js.UndefOr[String] = js.undefined,
-  disabled:    js.UndefOr[Boolean] = js.undefined,
-  placeholder: js.UndefOr[String] = js.undefined,
-  onFocus:     js.UndefOr[ReactFocusEventFromInput => Callback] = js.undefined,
-  onBlur:      js.UndefOr[ReactFocusEventFromInput => Callback] = js.undefined,
-  onChange:    js.UndefOr[ReactEventFromInput => Callback] = js.undefined,
-  onKeyDown:   js.UndefOr[ReactKeyboardEventFromInput => Callback] = js.undefined,
-  modifiers:   Seq[TagMod] = Seq.empty
+  id:             String,
+  clazz:          js.UndefOr[Css] = js.undefined,
+  value:          js.UndefOr[String] = js.undefined,
+  disabled:       js.UndefOr[Boolean] = js.undefined,
+  placeholder:    js.UndefOr[String] = js.undefined,
+  tooltip:        js.UndefOr[String] = js.undefined,
+  tooltipOptions: js.UndefOr[TooltipOptions] = js.undefined,
+  onFocus:        js.UndefOr[ReactFocusEventFromInput => Callback] = js.undefined,
+  onBlur:         js.UndefOr[ReactFocusEventFromInput => Callback] = js.undefined,
+  onChange:       js.UndefOr[ReactEventFromInput => Callback] = js.undefined,
+  onKeyDown:      js.UndefOr[ReactKeyboardEventFromInput => Callback] = js.undefined,
+  modifiers:      Seq[TagMod] = Seq.empty
 ) extends ReactFnProps[InputText](InputText.component) {
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
@@ -34,6 +37,8 @@ object InputText {
       .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
       .applyOrNot(props.disabled, _.disabled(_))
       .applyOrNot(props.placeholder, _.placeholder(_))
+      .applyOrNot(props.tooltip, _.tooltip(_))
+      .applyOrNot(props.tooltipOptions, (c, p) => c.tooltipOptions(p.asInstanceOf[CTooltipOptions]))
       .applyOrNot(props.onFocus, _.onFocus(_))
       .applyOrNot(props.onBlur, _.onBlur(_))
       .applyOrNot(props.onChange, _.onChange(_))

--- a/prime-react/src/main/scala/react/primereact/InputTextarea.scala
+++ b/prime-react/src/main/scala/react/primereact/InputTextarea.scala
@@ -7,21 +7,24 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import react.common.*
 import reactST.primereact.components.{InputTextarea => CInputTextarea}
+import reactST.primereact.tooltipTooltipoptionsMod.{TooltipOptions => CTooltipOptions}
 
 import scalajs.js
 
 case class InputTextarea(
-  id:          String,
-  clazz:       js.UndefOr[Css] = js.undefined,
-  value:       js.UndefOr[String] = js.undefined,
-  autoResize:  js.UndefOr[Boolean] = js.undefined,
-  disabled:    js.UndefOr[Boolean] = js.undefined,
-  placeholder: js.UndefOr[String] = js.undefined,
-  rows:        js.UndefOr[Int] = js.undefined,
-  onBlur:      js.UndefOr[ReactFocusEventFromTextArea => Callback] = js.undefined,
-  onChange:    js.UndefOr[ReactEventFromTextArea => Callback] = js.undefined,
-  onKeyDown:   js.UndefOr[ReactKeyboardEventFromTextArea => Callback] = js.undefined,
-  modifiers:   Seq[TagMod] = Seq.empty
+  id:             String,
+  clazz:          js.UndefOr[Css] = js.undefined,
+  value:          js.UndefOr[String] = js.undefined,
+  autoResize:     js.UndefOr[Boolean] = js.undefined,
+  disabled:       js.UndefOr[Boolean] = js.undefined,
+  placeholder:    js.UndefOr[String] = js.undefined,
+  rows:           js.UndefOr[Int] = js.undefined,
+  tooltip:        js.UndefOr[String] = js.undefined,
+  tooltipOptions: js.UndefOr[TooltipOptions] = js.undefined,
+  onBlur:         js.UndefOr[ReactFocusEventFromTextArea => Callback] = js.undefined,
+  onChange:       js.UndefOr[ReactEventFromTextArea => Callback] = js.undefined,
+  onKeyDown:      js.UndefOr[ReactKeyboardEventFromTextArea => Callback] = js.undefined,
+  modifiers:      Seq[TagMod] = Seq.empty
 ) extends ReactFnProps[InputTextarea](InputTextarea.component) {
   def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
   def withMods(mods:          TagMod*)     = addModifiers(mods)
@@ -36,6 +39,8 @@ object InputTextarea {
       .applyOrNot(props.autoResize, _.autoResize(_))
       .applyOrNot(props.disabled, _.disabled(_))
       .applyOrNot(props.placeholder, _.placeholder(_))
+      .applyOrNot(props.tooltip, _.tooltip(_))
+      .applyOrNot(props.tooltipOptions, (c, p) => c.tooltipOptions(p.asInstanceOf[CTooltipOptions]))
       .applyOrNot(props.onBlur, _.onBlur(_))
       .applyOrNot(props.onChange, _.onChange(_))
       .applyOrNot(props.onKeyDown, _.onKeyDown(_))

--- a/prime-react/src/main/scala/react/primereact/PrimeStyles.scala
+++ b/prime-react/src/main/scala/react/primereact/PrimeStyles.scala
@@ -38,6 +38,8 @@ trait PrimeStyles {
   val ButtonRounded: Css  = Css("p-button-rounded")
   val ButtonText: Css     = Css("p-button-text")
 
+  val ButtonSet: Css = Css("p-buttonset")
+
   // Tag
   val TagIcon: Css = Css("p-tag-icon")
 

--- a/prime-react/src/main/scala/react/primereact/RadioButton.scala
+++ b/prime-react/src/main/scala/react/primereact/RadioButton.scala
@@ -7,20 +7,23 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import react.common.*
 import reactST.primereact.components.{RadioButton => CRadioButton}
+import reactST.primereact.tooltipTooltipoptionsMod.{TooltipOptions => CTooltipOptions}
 
 import scalajs.js
 
 case class RadioButton[A](
-  value:     A,
-  id:        js.UndefOr[String] = js.undefined,
-  inputId:   js.UndefOr[String] = js.undefined, // id of the input element
-  name:      js.UndefOr[String] = js.undefined, // Name of the radio button
-  disabled:  js.UndefOr[Boolean] = js.undefined,
-  clazz:     js.UndefOr[Css] = js.undefined,
-  checked:   js.UndefOr[Boolean] = js.undefined,
-  required:  js.UndefOr[Boolean] = js.undefined,
-  onChange:  js.UndefOr[(A, Boolean) => Callback] = js.undefined,
-  modifiers: Seq[TagMod] = Seq.empty
+  value:          A,
+  id:             js.UndefOr[String] = js.undefined,
+  inputId:        js.UndefOr[String] = js.undefined, // id of the input element
+  name:           js.UndefOr[String] = js.undefined, // Name of the radio button
+  disabled:       js.UndefOr[Boolean] = js.undefined,
+  clazz:          js.UndefOr[Css] = js.undefined,
+  checked:        js.UndefOr[Boolean] = js.undefined,
+  required:       js.UndefOr[Boolean] = js.undefined,
+  tooltip:        js.UndefOr[String] = js.undefined,
+  tooltipOptions: js.UndefOr[TooltipOptions] = js.undefined,
+  onChange:       js.UndefOr[(A, Boolean) => Callback] = js.undefined,
+  modifiers:      Seq[TagMod] = Seq.empty
 ) extends ReactFnProps[RadioButton[Any]](RadioButton.component) {
 
   protected def valueFinder(i: Any): A = i.asInstanceOf[A]
@@ -41,6 +44,8 @@ object RadioButton {
       .applyOrNot(props.checked, _.checked(_))
       .applyOrNot(props.required, _.required(_))
       .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
+      .applyOrNot(props.tooltip, _.tooltip(_))
+      .applyOrNot(props.tooltipOptions, (c, p) => c.tooltipOptions(p.asInstanceOf[CTooltipOptions]))
       .applyOrNot(
         props.onChange,
         (c, p) => c.onChange(scp => p(props.valueFinder(scp.value), scp.checked))

--- a/prime-react/src/main/scala/react/primereact/SelectButton.scala
+++ b/prime-react/src/main/scala/react/primereact/SelectButton.scala
@@ -20,6 +20,8 @@ case class SelectButton[A](
   disabled:       js.UndefOr[Boolean] = js.undefined,
   itemTemplate:   js.UndefOr[SelectItem[A] => VdomNode] = js.undefined,
   clazz:          js.UndefOr[Css] = js.undefined,
+  tooltip:        js.UndefOr[String] = js.undefined,
+  tooltipOptions: js.UndefOr[TooltipOptions] = js.undefined,
   onChange:       js.UndefOr[A => Callback] = js.undefined,
   modifiers:      Seq[TagMod] = Seq.empty
 )(using val eqAA: Eq[A])

--- a/prime-react/src/main/scala/react/primereact/SelectButtonBase.scala
+++ b/prime-react/src/main/scala/react/primereact/SelectButtonBase.scala
@@ -9,6 +9,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import react.common.*
 import reactST.primereact.components.{SelectButton => CSelectButton}
 import reactST.primereact.selectitemSelectitemMod.{SelectItem => CSelectItem}
+import reactST.primereact.tooltipTooltipoptionsMod.{TooltipOptions => CTooltipOptions}
 
 import scalajs.js
 import scalajs.js.JSConverters.*
@@ -26,6 +27,8 @@ private[primereact] trait SelectButtonBase {
   val unselectable: js.UndefOr[Boolean] // default: true
   val itemTemplate: js.UndefOr[SelectItem[AA] => VdomNode]
   val clazz: js.UndefOr[Css]
+  val tooltip: js.UndefOr[String]
+  val tooltipOptions: js.UndefOr[TooltipOptions]
   val onChange: js.UndefOr[GG[AA] => Callback]
   val modifiers: Seq[TagMod]
 
@@ -57,6 +60,8 @@ object SelectButtonBase {
           )
       )
       .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
+      .applyOrNot(props.tooltip, _.tooltip(_))
+      .applyOrNot(props.tooltipOptions, (c, p) => c.tooltipOptions(p.asInstanceOf[CTooltipOptions]))
       .applyOrNot(props.onChange, (c, p) => c.onChange(e => p(props.valueFinder(e.value))))(
         props.modifiers.toTagMod
       )

--- a/prime-react/src/main/scala/react/primereact/SelectButtonMultiple.scala
+++ b/prime-react/src/main/scala/react/primereact/SelectButtonMultiple.scala
@@ -19,6 +19,8 @@ case class SelectButtonMultiple[A](
   disabled:       js.UndefOr[Boolean] = js.undefined,
   itemTemplate:   js.UndefOr[SelectItem[A] => VdomNode] = js.undefined,
   clazz:          js.UndefOr[Css] = js.undefined,
+  tooltip:        js.UndefOr[String] = js.undefined,
+  tooltipOptions: js.UndefOr[TooltipOptions] = js.undefined,
   onChange:       js.UndefOr[List[A] => Callback] = js.undefined,
   modifiers:      Seq[TagMod] = Seq.empty
 )(using val eqAA: Eq[A])

--- a/prime-react/src/main/scala/react/primereact/SelectButtonOptional.scala
+++ b/prime-react/src/main/scala/react/primereact/SelectButtonOptional.scala
@@ -19,6 +19,8 @@ case class SelectButtonOptional[A](
   disabled:       js.UndefOr[Boolean] = js.undefined,
   itemTemplate:   js.UndefOr[SelectItem[A] => VdomNode] = js.undefined,
   clazz:          js.UndefOr[Css] = js.undefined,
+  tooltip:        js.UndefOr[String] = js.undefined,
+  tooltipOptions: js.UndefOr[TooltipOptions] = js.undefined,
   onChange:       js.UndefOr[Option[A] => Callback] = js.undefined,
   modifiers:      Seq[TagMod] = Seq.empty
 )(using val eqAA: Eq[A])


### PR DESCRIPTION
This also adds an `onChangeE` event to the Dropdowns. I ended up not needing it, but left it because it could be useful. If someone feels it should be removed, I can pull it out.