### PR TITLE
Fix table `emptyMessage`

### DIFF
--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -176,13 +176,14 @@ trait HTMLTableRenderer[T]:
           .whenDefined
       )(
         TagMod.when(rows.isEmpty)(
-          <.tr(
-            TbodyTrClass,
-            EmptyMessage,
-            ^.colSpan := table.getAllLeafColumns().length,
-            ^.whiteSpace.nowrap
-          )(
-            emptyMessage
+          <.tr(TbodyTrClass,
+               <.td(EmptyMessage,
+                    TbodyTdClass,
+                    ^.colSpan := table.getAllLeafColumns().length,
+                    ^.whiteSpace.nowrap
+               )(
+                 emptyMessage
+               )
           )
         ),
         rows.zipWithIndex


### PR DESCRIPTION
When the empty message for an prime html table was displayed, react-devtools would display a big, red `ValidateDomNesting` warning like
> Text nodes cannot appear as a child of \<tr>.

or
> \<div> cannot appear as a child of `<tr>

depending on the  value of the emptyMessage.