### PR TITLE
Fix cols in rgl facade, add Layout.asList

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.39"
+ThisBuild / tlBaseVersion       := "0.40"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.38"
+ThisBuild / tlBaseVersion       := "0.39"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/grid-layout/src/main/scala/react/gridlayout/BaseProps.scala
+++ b/grid-layout/src/main/scala/react/gridlayout/BaseProps.scala
@@ -21,8 +21,6 @@ trait BaseProps extends js.Object {
   var width: Double
   // If true, the container height swells and contracts to fit contents
   var autoSize: js.UndefOr[Boolean]
-  // # of cols.
-  var cols: js.UndefOr[Int]
   // A selector that will not be draggable.
   var draggableCancel: js.UndefOr[String]
   // A selector for the draggable handler
@@ -93,7 +91,6 @@ object BaseProps {
     className:        js.UndefOr[String] = js.undefined,
     style:            js.UndefOr[Style] = js.undefined,
     autoSize:         js.UndefOr[Boolean] = js.undefined,
-    cols:             js.UndefOr[Int] = js.undefined,
     draggableCancel:  js.UndefOr[String] = js.undefined,
     draggableHandle:  js.UndefOr[String] = js.undefined,
     verticalCompact:  js.UndefOr[Boolean] = js.undefined,
@@ -124,7 +121,6 @@ object BaseProps {
     p.width = width
     p.style = style.map(_.toJsObject)
     p.autoSize = autoSize
-    p.cols = cols
     p.draggableCancel = draggableCancel
     p.draggableHandle = draggableHandle
     p.verticalCompact = verticalCompact

--- a/grid-layout/src/main/scala/react/gridlayout/ReactGridLayout.scala
+++ b/grid-layout/src/main/scala/react/gridlayout/ReactGridLayout.scala
@@ -62,6 +62,8 @@ object ReactGridLayout {
 
   @js.native
   trait ReactGridLayoutProps extends BaseProps {
+    // # of cols.
+    var cols: js.UndefOr[Int]
     // layout is an array of object with the format:
     // {x: Number, y: Number, w: Number, h: Number, i: String}
     var layout: js.UndefOr[raw.Layout]
@@ -142,7 +144,6 @@ object ReactGridLayout {
       className,
       style,
       autoSize,
-      cols,
       draggableCancel,
       draggableHandle,
       verticalCompact,
@@ -169,6 +170,7 @@ object ReactGridLayout {
       onDrop
     )
     val r = p.asInstanceOf[ReactGridLayoutProps]
+    r.cols = cols
     r.layout = layout.toRaw
     r.onLayoutChange = (x: raw.Layout) => onLayoutChange(Layout.fromRaw(x)).runNow()
     r

--- a/grid-layout/src/main/scala/react/gridlayout/ResponsiveReactGridLayout.scala
+++ b/grid-layout/src/main/scala/react/gridlayout/ResponsiveReactGridLayout.scala
@@ -22,7 +22,6 @@ final case class ResponsiveReactGridLayout(
   className:              js.UndefOr[String] = js.undefined,
   style:                  js.UndefOr[Style] = js.undefined,
   autoSize:               js.UndefOr[Boolean] = js.undefined,
-  cols:                   js.UndefOr[Int] = js.undefined,
   draggableCancel:        js.UndefOr[String] = js.undefined,
   draggableHandle:        js.UndefOr[String] = js.undefined,
   verticalCompact:        js.UndefOr[Boolean] = js.undefined,
@@ -72,7 +71,7 @@ object ResponsiveReactGridLayout {
     // Breakpoint names are arbitrary but must match in the cols and layouts objects.
     var breakpoints: js.Object = js.native
     // # of cols. This is a breakpoint -> cols map, e.g. {lg: 12, md: 10, ...}
-    var columns: js.Object     = js.native
+    var cols: js.Object        = js.native
     // layouts is an object mapping breakpoints to layouts.
     // e.g. {lg: Layout, md: Layout, ...}
     var layouts: js.Object     = js.native
@@ -97,7 +96,6 @@ object ResponsiveReactGridLayout {
       q.className,
       q.style,
       q.autoSize,
-      q.cols,
       q.draggableCancel,
       q.draggableHandle,
       q.verticalCompact,
@@ -133,7 +131,6 @@ object ResponsiveReactGridLayout {
     className:          js.UndefOr[String] = js.undefined,
     style:              js.UndefOr[Style] = js.undefined,
     autoSize:           js.UndefOr[Boolean] = js.undefined,
-    cols:               js.UndefOr[Int] = js.undefined,
     draggableCancel:    js.UndefOr[String] = js.undefined,
     draggableHandle:    js.UndefOr[String] = js.undefined,
     verticalCompact:    js.UndefOr[Boolean] = js.undefined,
@@ -167,7 +164,6 @@ object ResponsiveReactGridLayout {
       className,
       style,
       autoSize,
-      cols,
       draggableCancel,
       draggableHandle,
       verticalCompact,
@@ -196,7 +192,7 @@ object ResponsiveReactGridLayout {
     val r                                           = p.asInstanceOf[ResponsiveReactGridLayoutProps]
     val (br: Breakpoints, cl: Columns, ly: Layouts) = build(layouts)
     r.breakpoints = br.toRaw
-    r.columns = cl.toRaw
+    r.cols = cl.toRaw
     r.layouts = ly.toRaw
     r.onBreakpointChange = (newBreakpoint: raw.Breakpoint, newCol: Int) =>
       onBreakpointChange(BreakpointName(newBreakpoint), newCol).runNow()

--- a/grid-layout/src/main/scala/react/gridlayout/package.scala
+++ b/grid-layout/src/main/scala/react/gridlayout/package.scala
@@ -158,7 +158,7 @@ package gridlayout {
     h:             Int,
     x:             Int,
     y:             Int,
-    i:             js.UndefOr[String] = js.undefined,
+    i:             String,
     minW:          js.UndefOr[Int] = js.undefined,
     minH:          js.UndefOr[Int] = js.undefined,
     maxW:          js.UndefOr[Int] = js.undefined,

--- a/grid-layout/src/main/scala/react/gridlayout/package.scala
+++ b/grid-layout/src/main/scala/react/gridlayout/package.scala
@@ -4,6 +4,7 @@
 package react
 
 import cats.*
+import cats.derived.*
 import japgolly.scalajs.react.Callback
 import org.scalajs.dom.Event
 import org.scalajs.dom.MouseEvent
@@ -77,13 +78,9 @@ package gridlayout {
     val predefined: List[BreakpointName] = List(xxl, xl, lg, md, sm, xs, xxs)
   }
 
-  case class Breakpoint(name: BreakpointName, pos: Int)
+  case class Breakpoint(name: BreakpointName, pos: Int) derives Eq
 
-  object Breakpoint {
-    given Eq[Breakpoint] = Eq.by(x => (x.name, x.pos))
-  }
-
-  case class Breakpoints(bps: List[Breakpoint]) {
+  case class Breakpoints(bps: List[Breakpoint]) derives Eq {
     def toRaw: js.Object = {
       val p = js.Dynamic.literal()
       bps.foreach { case Breakpoint(name, v) => p.updateDynamic(name.name)(v.asInstanceOf[js.Any]) }
@@ -91,14 +88,7 @@ package gridlayout {
     }
   }
 
-  object Breakpoints {
-    given Eq[Breakpoints] = Eq.by(_.bps)
-  }
-
-  case class Column(col: BreakpointName, pos: Int)
-  object Column {
-    given Eq[Column] = Eq.by(x => (x.col, x.pos))
-  }
+  case class Column(col: BreakpointName, pos: Int) derives Eq
 
   opaque type Columns = List[Column]
 
@@ -131,11 +121,9 @@ package gridlayout {
     }
   }
 
-  case class BreakpointLayout(name: BreakpointName, layout: Layout)
+  case class BreakpointLayout(name: BreakpointName, layout: Layout) derives Eq
 
   object BreakpointLayout {
-    given Eq[BreakpointLayout] = Eq.by(x => (x.name, x.layout))
-
     private[gridlayout] def layoutsFromRaw(l: js.Object): Layout = {
       val c                   = l.asInstanceOf[js.Array[raw.LayoutItem]]
       val i: List[LayoutItem] = c.map(LayoutItem.fromRaw).toList
@@ -180,7 +168,7 @@ package gridlayout {
     isResizable:   js.UndefOr[Boolean] = js.undefined,
     resizeHandles: js.UndefOr[List[ResizeHandle]] = js.undefined,
     isBounded:     js.UndefOr[Boolean] = js.undefined
-  ) {
+  ) derives Eq {
     def toRaw: raw.LayoutItem =
       new raw.LayoutItem(w,
                          h,
@@ -201,24 +189,6 @@ package gridlayout {
 
   object LayoutItem {
     private given eqUndef[A: Eq]: Eq[js.UndefOr[A]] = Eq.by(_.toOption)
-    given eqLayoutItem: Eq[LayoutItem]              = Eq.by(x =>
-      (x.w,
-       x.h,
-       x.x,
-       x.y,
-       x.y,
-       x.i,
-       x.minW,
-       x.minH,
-       x.maxW,
-       x.maxH,
-       x.static,
-       x.isDraggable,
-       x.isResizable,
-       x.resizeHandles,
-       x.isBounded
-      )
-    )
 
     private[gridlayout] def fromRaw(l: raw.LayoutItem): LayoutItem =
       new LayoutItem(
@@ -273,6 +243,7 @@ package gridlayout {
 
     extension (l: Layout)
       private[gridlayout] inline def toRaw: raw.Layout = l.toArray.map(_.toRaw).toJSArray
+      inline def asList: List[LayoutItem]              = l
 
     given (using eq: Eq[List[LayoutItem]]): Eq[Layout] = eq
 

--- a/grid-layout/src/main/scala/react/gridlayout/raw/package.scala
+++ b/grid-layout/src/main/scala/react/gridlayout/raw/package.scala
@@ -46,7 +46,7 @@ package raw {
     val h:             Int,
     val x:             Int,
     val y:             Int,
-    val i:             js.UndefOr[String] = js.undefined,
+    val i:             String,
     val minW:          js.UndefOr[Int] = js.undefined,
     val minH:          js.UndefOr[Int] = js.undefined,
     val maxW:          js.UndefOr[Int] = js.undefined,


### PR DESCRIPTION
Changing the type of `cols` did not fix the problem in Explore, but needed to be fixed anyway. 

`Layout.asList` is needed for merging the layouts in Explore.

Also make `LayoutItem.i` mandatory - it is mandatory in the typescript.