### PR TITLE
Better layered icons types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.42"
+ThisBuild / tlBaseVersion       := "0.43"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/font-awesome/src/main/scala/lucuma/react/fa/LayeredIcon.scala
+++ b/font-awesome/src/main/scala/lucuma/react/fa/LayeredIcon.scala
@@ -32,10 +32,16 @@ case class LayeredIcon(
   spinReverse: Boolean = false,
   swapOpacity: Boolean = false,
   modifiers:   List[TagMod] = List.empty
-) extends ReactFnPropsWithChildren(LayeredIcon.component)
+) extends ReactFnProps(LayeredIcon.component)
     with IconProps:
-  def withMods(mods: TagMod*): LayeredIcon = copy(modifiers = modifiers ++ mods)
-  override def faClasses: Css = super.faClasses // For some reason this is necessary (?!?!?)
+  def apply(mods: TagMod | FontAwesomeIcon | TextLayer | CounterLayer*): LayeredIcon =
+    copy(modifiers = modifiers ++ mods.map:
+      case t: TagMod          => t
+      case c: FontAwesomeIcon => c: VdomElement
+      case c: TextLayer       => c: VdomElement
+      case c: CounterLayer    => c: VdomElement
+    )
+  override def faClasses: Css                                                        = super.faClasses // For some reason this is necessary (?!?!?)
 
   def addClass(value:        Css)            = copy(clazz = clazz |+| value)
   def withClass(value:       Css)            = copy(clazz = value)
@@ -63,8 +69,5 @@ object LayeredIcon:
   private type Props = LayeredIcon
 
   private val component =
-    ScalaFnComponent
-      .withHooks[Props]
-      .withPropsChildren
-      .render: (props, children) =>
-        <.span(Css("fa-layers") |+| props.faClasses, props.modifiers.toTagMod)(children)
+    ScalaFnComponent[Props]: props =>
+      <.span(Css("fa-layers") |+| props.faClasses, props.modifiers.toTagMod) // (props.children: _*)

--- a/font-awesome/src/main/scala/lucuma/react/fa/TextLayer.scala
+++ b/font-awesome/src/main/scala/lucuma/react/fa/TextLayer.scala
@@ -7,6 +7,7 @@ import cats.syntax.all.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.*
+import lucuma.react.fa.*
 
 import scala.scalajs.js
 


### PR DESCRIPTION
This PR provides more type safety on layered icon's children and allows calling `with*` methods on a `LayeredIcon` since children rendering is resolved at render time instead of definition.