### PR TITLE
Implement InputGroup

### DIFF
--- a/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
+++ b/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
@@ -294,9 +294,16 @@ object DemoControlsPanel {
                   onChange = toggleButton.setState
                 )
               ),
-              <.label("ProgressBar 1",
-                      ^.htmlFor             := "progress-indeterminate",
-                      DemoStyles.FormFieldLabel
+              <.label("InputGroup", DemoStyles.FormFieldLabel),
+              InputGroup(
+                InputGroup.Addon("$"),
+                InputText(id = "price", placeholder = "Price"),
+                InputGroup.Addon(".00")
+              ),
+              <.label(
+                "ProgressBar 1",
+                ^.htmlFor                   := "progress-indeterminate",
+                DemoStyles.FormFieldLabel
               ),
               ProgressBar(id = "progress-indeterminate", mode = ProgressBar.Mode.Indeterminate),
               <.div(

--- a/prime-react/src/main/scala/lucuma/react/primereact/InputGroup.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/InputGroup.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.primereact
+
+import lucuma.react.common.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+
+case class InputGroup(mods: TagMod*) extends ReactFnProps(InputGroup.component):
+  def apply(moreMods: TagMod*): InputGroup = InputGroup((mods ++ moreMods): _*)
+
+object InputGroup:
+  private type Props = InputGroup
+
+  private val component = ScalaFnComponent[Props]: props =>
+    <.div(Css("p-inputgroup"), props.mods.toTagMod)
+
+  case class Addon(mods: TagMod*) extends ReactFnProps(Addon.component):
+    def apply(moreMods: TagMod*): Addon = Addon((mods ++ moreMods): _*)
+
+  object Addon:
+    private type Props = Addon
+
+    private val component = ScalaFnComponent[Props]: props =>
+      <.span(Css("p-inputgroup-addon"), props.mods.toTagMod)


### PR DESCRIPTION
Although documented as a component (https://primereact.org/inputgroup/), `InputGroup` is actually a `<div>` with a certain Prime class.

This PR implements it as an actual component so that we don't have to reference specific Prime classes in final code.