### PR TITLE
Modernize react-common, Renderable instances

### DIFF
--- a/common/src/main/scala/lucuma/react/common/givens/package.scala
+++ b/common/src/main/scala/lucuma/react/common/givens/package.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.react.common.implicits
+package lucuma.react.common.givens
 
 import cats.*
 import cats.syntax.all.*

--- a/common/src/main/scala/lucuma/react/common/jsComponents.scala
+++ b/common/src/main/scala/lucuma/react/common/jsComponents.scala
@@ -26,17 +26,47 @@ class AttrsBuilder(p: js.Object) extends VdomBuilder.ToJs {
 
 trait GenericFnComponent[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U] {
   protected def cprops: P
-  @inline def render: RenderFn[P]
+  def render: RenderFn[P]
 }
+
+object GenericFnComponent:
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U]
+    : Conversion[GenericFnComponent[P, CT, U], RenderFn[P]] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U]
+    : Conversion[GenericFnComponent[P, CT, U], VdomNode] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U]
+    : Conversion[GenericFnComponent[P, CT, U], js.UndefOr[VdomNode]] =
+    _.render
 
 trait GenericFnComponentC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A] {
   protected def cprops: P
   val children: CtorType.ChildrenArgs
   def withChildren(children: CtorType.ChildrenArgs): A
 
-  @inline def renderWith: RenderFnC[P]
-  @inline def render: RenderFn[P] = renderWith(children)
+  def renderWith: RenderFnC[P]
+  def render: RenderFn[P] = renderWith(children)
 }
+
+object GenericFnComponentC:
+  extension [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A](
+    c: GenericFnComponentC[P, CT, U, A]
+  ) def apply(children: VdomNode*): A = c.withChildren(children)
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentC[P, CT, U, A], RenderFn[P]] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentC[P, CT, U, A], VdomNode] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentC[P, CT, U, A], js.UndefOr[VdomNode]] =
+    _.render
 
 trait Passthrough[P <: js.Object] {
   protected def cprops: P
@@ -66,26 +96,60 @@ trait GenericFnComponentA[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
   protected val component: JsFn.Component[P, CT]
   def addModifiers(modifiers: Seq[TagMod]): A
 
-  @inline def render: RenderFn[P] = component.applyGeneric(rawProps)()
+  inline def render: RenderFn[P] = component.applyGeneric(rawProps)()
 }
+
+object GenericFnComponentA:
+  extension [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A](
+    c: GenericFnComponentA[P, CT, U, A]
+  ) def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentA[P, CT, U, A], RenderFn[P]] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentA[P, CT, U, A], VdomNode] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentA[P, CT, U, A], js.UndefOr[VdomNode]] =
+    _.render
 
 trait GenericFnComponentAC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
     extends PassthroughAC[P] {
   protected val component: JsFn.Component[P, CT]
   def addModifiers(modifiers: Seq[TagMod]): A
 
-  @inline def render: RenderFn[P] = {
+  inline def render: RenderFn[P] = {
     val (props, children) = rawModifiers
     component.applyGeneric(props)(children: _*)
   }
 }
 
+object GenericFnComponentAC:
+  extension [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A](
+    c: GenericFnComponentAC[P, CT, U, A]
+  ) def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentAC[P, CT, U, A], RenderFn[P]] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentAC[P, CT, U, A], VdomNode] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericFnComponentAC[P, CT, U, A], js.UndefOr[VdomNode]] =
+    _.render
+
 trait GenericJsComponent[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U] { self =>
   protected def cprops: P
   protected val component: Js.Component[P, Null, CT]
 
-  def rawProps: P               = cprops
-  @inline def render: Render[P] = component.applyGeneric(rawProps)()
+  def rawProps: P              = cprops
+  inline def render: Render[P] = component.applyGeneric(rawProps)()
 
   private def copyComponent(
     newComponent: Js.Component[P, Null, CT]
@@ -104,15 +168,28 @@ trait GenericJsComponent[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U] { self
     copyComponent(self.component.withOptionalRef(ref))
 }
 
+object GenericJsComponent:
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U]
+    : Conversion[GenericJsComponent[P, CT, U], Render[P]] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U]
+    : Conversion[GenericJsComponent[P, CT, U], VdomNode] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U]
+    : Conversion[GenericJsComponent[P, CT, U], js.UndefOr[VdomNode]] =
+    _.render
+
 trait GenericJsComponentC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A] { self =>
   protected def cprops: P
   val children: CtorType.ChildrenArgs
   def withChildren(children: CtorType.ChildrenArgs): A
   protected val component: Js.Component[P, Null, CT]
 
-  def rawProps: P                    = cprops
-  @inline def renderWith: RenderC[P] = component.applyGeneric(rawProps)
-  @inline def render: Render[P]      = renderWith(children)
+  def rawProps: P                   = cprops
+  inline def renderWith: RenderC[P] = component.applyGeneric(rawProps)
+  inline def render: Render[P]      = renderWith(children)
 
   private def copyComponent(
     newComponent: Js.Component[P, Null, CT]
@@ -133,12 +210,29 @@ trait GenericJsComponentC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A] { 
     copyComponent(self.component.withOptionalRef(ref))
 }
 
+object GenericJsComponentC:
+  extension [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A](
+    c: GenericJsComponentC[P, CT, U, A]
+  ) def apply(children: VdomNode*): A = c.withChildren(children)
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentC[P, CT, U, A], Render[P]] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentC[P, CT, U, A], VdomNode] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentC[P, CT, U, A], js.UndefOr[VdomNode]] =
+    _.render
+
 trait GenericJsComponentA[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
     extends PassthroughA[P] { self =>
   protected val component: Js.Component[P, Null, CT]
   def addModifiers(modifiers: Seq[TagMod]): A
 
-  @inline def render: Render[P] = component.applyGeneric(rawProps)()
+  inline def render: Render[P] = component.applyGeneric(rawProps)()
 
   private def copyComponent(
     newComponent: Js.Component[P, Null, CT]
@@ -159,12 +253,29 @@ trait GenericJsComponentA[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
     copyComponent(self.component.withOptionalRef(ref))
 }
 
+object GenericJsComponentA:
+  extension [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A](
+    c: GenericJsComponentA[P, CT, U, A]
+  ) def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentA[P, CT, U, A], Render[P]] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentA[P, CT, U, A], VdomNode] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentA[P, CT, U, A], js.UndefOr[VdomNode]] =
+    _.render
+
 trait GenericJsComponentAC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
     extends PassthroughAC[P] { self =>
   protected val component: Js.Component[P, Null, CT]
   def addModifiers(modifiers: Seq[TagMod]): A
 
-  @inline def render: Render[P] = {
+  inline def render: Render[P] = {
     val (props, children) = rawModifiers
     component.applyGeneric(props)(children: _*)
   }
@@ -188,12 +299,29 @@ trait GenericJsComponentAC[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
     copyComponent(self.component.withOptionalRef(ref))
 }
 
+object GenericJsComponentAC:
+  extension [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A](
+    c: GenericJsComponentAC[P, CT, U, A]
+  ) def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentAC[P, CT, U, A], Render[P]] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentAC[P, CT, U, A], VdomNode] =
+    _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A]
+    : Conversion[GenericJsComponentAC[P, CT, U, A], js.UndefOr[VdomNode]] =
+    _.render
+
 trait GenericJsComponentF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, F <: js.Object] { self =>
   protected def cprops: P
   protected val component: Js.ComponentWithFacade[P, Null, F, CT]
 
-  def rawProps: P                   = cprops
-  @inline def render: RenderF[P, F] = component.applyGeneric(rawProps)()
+  def rawProps: P                  = cprops
+  inline def render: RenderF[P, F] = component.applyGeneric(rawProps)()
 
   private def copyComponent(
     newComponent: Js.ComponentWithFacade[P, Null, F, CT]
@@ -212,6 +340,13 @@ trait GenericJsComponentF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, F <: 
     copyComponent(self.component.withOptionalRef(ref))
 }
 
+object GenericJsComponentF:
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, F <: js.Object]
+    : Conversion[GenericJsComponentF[P, CT, U, F], VdomNode] = _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, F <: js.Object]
+    : Conversion[GenericJsComponentF[P, CT, U, F], js.UndefOr[VdomNode]] = _.render
+
 trait GenericJsComponentCF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object] {
   self =>
   protected def cprops: P
@@ -219,9 +354,9 @@ trait GenericJsComponentCF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F
   def withChildren(children: CtorType.ChildrenArgs): A
   protected val component: Js.ComponentWithFacade[P, Null, F, CT]
 
-  def rawProps: P                        = cprops
-  @inline def renderWith: RenderCF[P, F] = component.applyGeneric(rawProps)
-  @inline def render: RenderF[P, F]      = renderWith(children)
+  def rawProps: P                       = cprops
+  inline def renderWith: RenderCF[P, F] = component.applyGeneric(rawProps)
+  inline def render: RenderF[P, F]      = renderWith(children)
 
   private def copyComponent(
     newComponent: Js.ComponentWithFacade[P, Null, F, CT]
@@ -244,12 +379,19 @@ trait GenericJsComponentCF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F
     copyComponent(self.component.withOptionalRef(ref))
 }
 
+object GenericJsComponentCF:
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
+    : Conversion[GenericJsComponentCF[P, CT, U, A, F], VdomNode] = _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
+    : Conversion[GenericJsComponentCF[P, CT, U, A, F], js.UndefOr[VdomNode]] = _.render
+
 trait GenericJsComponentAF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
     extends PassthroughA[P] { self =>
   protected val component: Js.ComponentWithFacade[P, Null, F, CT]
   def addModifiers(modifiers: Seq[TagMod]): A
 
-  @inline def render: RenderF[P, F] = component.applyGeneric(rawProps)()
+  inline def render: RenderF[P, F] = component.applyGeneric(rawProps)()
 
   private def copyComponent(
     newComponent: Js.ComponentWithFacade[P, Null, F, CT]
@@ -272,12 +414,19 @@ trait GenericJsComponentAF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F
     copyComponent(self.component.withOptionalRef(ref))
 }
 
+object GenericJsComponentAF:
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
+    : Conversion[GenericJsComponentAF[P, CT, U, A, F], VdomNode] = _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
+    : Conversion[GenericJsComponentAF[P, CT, U, A, F], js.UndefOr[VdomNode]] = _.render
+
 trait GenericJsComponentACF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
     extends PassthroughAC[P] { self =>
   protected val component: Js.ComponentWithFacade[P, Null, F, CT]
   def addModifiers(modifiers: Seq[TagMod]): A
 
-  @inline def render: RenderF[P, F] = {
+  inline def render: RenderF[P, F] = {
     val (props, children) = rawModifiers
     component.applyGeneric(props)(children: _*)
   }
@@ -302,3 +451,10 @@ trait GenericJsComponentACF[P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, 
   ): GenericJsComponentACF[P, CT, U, A, F] =
     copyComponent(self.component.withOptionalRef(ref))
 }
+
+object GenericJsComponentACF:
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
+    : Conversion[GenericJsComponentACF[P, CT, U, A, F], VdomNode] = _.render
+
+  given [P <: js.Object, CT[-p, +u] <: CtorType[p, u], U, A, F <: js.Object]
+    : Conversion[GenericJsComponentACF[P, CT, U, A, F], js.UndefOr[VdomNode]] = _.render

--- a/common/src/main/scala/lucuma/react/common/package.scala
+++ b/common/src/main/scala/lucuma/react/common/package.scala
@@ -1,152 +1,75 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.react
+package lucuma.react.common
 
-import japgolly.scalajs.react._
+import japgolly.scalajs.react.*
 import japgolly.scalajs.react.component.Generic
-import japgolly.scalajs.react.component.Js._
-import japgolly.scalajs.react.component.Scala
-import japgolly.scalajs.react.component.ScalaFn
-import japgolly.scalajs.react.component.ScalaForwardRef
-import japgolly.scalajs.react.vdom.TagMod
-import japgolly.scalajs.react.vdom.VdomElement
-import japgolly.scalajs.react.vdom.VdomNode
-import lucuma.react.common.syntax.AllSyntax
+import japgolly.scalajs.react.component.Js.*
 
-import scala.language.implicitConversions
 import scala.scalajs.js
 
-package object common extends AllSyntax {
+private def merge(a: js.Object, b: js.Object): js.Object = {
+  val m = js.Dictionary.empty[js.Any]
+  val c = a.asInstanceOf[js.Dictionary[js.Any]]
+  for {
+    p <- js.Object.getOwnPropertyNames(a)
+    v <- c.get(p)
+  } yield m(p) = v
 
-  def merge(a: js.Object, b: js.Object): js.Object = {
-    val m = js.Dictionary.empty[js.Any]
-    val c = a.asInstanceOf[js.Dictionary[js.Any]]
-    for {
-      p <- js.Object.getOwnPropertyNames(a)
-      v <- c.get(p)
-    } yield m(p) = v
+  val d = b.asInstanceOf[js.Dictionary[js.Any]]
+  for {
+    p <- js.Object.getOwnPropertyNames(b)
+    v <- d.get(p)
+  } yield m(p) = v
 
-    val d = b.asInstanceOf[js.Dictionary[js.Any]]
-    for {
-      p <- js.Object.getOwnPropertyNames(b)
-      v <- d.get(p)
-    } yield m(p) = v
-
-    m.asInstanceOf[js.Object]
-  }
-
-  def filterProps[P <: js.Object](p: P, name: String, names: String*): P = {
-    val o = js.Dictionary.empty[js.Any]
-    val c = p.asInstanceOf[js.Dictionary[js.Any]]
-    for {
-      k <- js.Object.getOwnPropertyNames(p) if name != k && !names.contains(k)
-      v <- c.get(k)
-    } yield o(k) = v
-    o.asInstanceOf[P]
-  }
-
-  val Style = style.Style
-  val Css   = style.Css
-  type Style = style.Style
-  type Css   = style.Css
-
-  // Begin Scala Components
-  @inline implicit def props2Component[Props, S, B, CT[-p, +u] <: CtorType[p, u]](
-    p: ReactRender[Props, CT, Scala.Unmounted[Props, S, B]]
-  ): VdomElement =
-    p.toUnmounted
-
-  implicit class PropsWithChildren2Component[Props, S, B](
-    p: ReactRender[Props, CtorType.PropsAndChildren, Scala.Unmounted[Props, S, B]]
-  ) {
-    @inline def apply(first: CtorType.ChildArg, rest: CtorType.ChildArg*): VdomElement =
-      p(first, rest: _*)
-  }
-
-  @inline implicit def fnProps2Component[Props, CT[-p, +u] <: CtorType[p, u]](
-    p: ReactRender[Props, CT, ScalaFn.Unmounted[Props]]
-  ): VdomElement =
-    p.toUnmounted
-
-  implicit class FnPropsWithChildren2Component[Props](
-    p: ReactRender[Props, CtorType.PropsAndChildren, ScalaFn.Unmounted[Props]]
-  ) {
-    @inline def apply(first: CtorType.ChildArg, rest: CtorType.ChildArg*): VdomElement =
-      p(first, rest: _*)
-  }
-
-  @inline implicit def propsForwardRef2Component[Props, R, CT[-p, +u] <: CtorType[p, u]](
-    p: ReactRender[Props, CT, ScalaForwardRef.Unmounted[Props, R]]
-  ): VdomElement =
-    p.toUnmounted
-
-  implicit class PropsForwardRefWithChildren2Component[Props, R](
-    p: ReactRender[Props, CtorType.PropsAndChildren, ScalaForwardRef.Unmounted[Props, R]]
-  ) {
-    @inline def apply(first: CtorType.ChildArg, rest: CtorType.ChildArg*): VdomElement =
-      p(first, rest: _*)
-  }
-  // End Scala Components
-
-  // Begin JS Components
-  type RenderFn[P]                              = Generic.Unmounted[P, Unit]
-  type Render[P <: js.Object]                   = Unmounted[P, Null]
-  type RenderF[P <: js.Object, F <: js.Object]  = UnmountedWithFacade[P, Null, F]
-  type RenderFnC[P]                             = CtorType.ChildrenArgs => RenderFn[P]
-  type RenderC[P <: js.Object]                  = CtorType.ChildrenArgs => Render[P]
-  type RenderCF[P <: js.Object, F <: js.Object] = CtorType.ChildrenArgs => RenderF[P, F]
-
-  type GenericFnComponentP[P <: js.Object]      = GenericFnComponent[P, CtorType.Props, Unit]
-  type GenericFnComponentPC[P <: js.Object, A]  =
-    GenericFnComponentC[P, CtorType.PropsAndChildren, Unit, A]
-  type GenericFnComponentPA[P <: js.Object, A]  = GenericFnComponentA[P, CtorType.Props, Unit, A]
-  type GenericFnComponentPAC[P <: js.Object, A] =
-    GenericFnComponentAC[P, CtorType.PropsAndChildren, Unit, A]
-
-  type GenericComponentP[P <: js.Object]      = GenericJsComponent[P, CtorType.Props, Unit]
-  type GenericComponentPC[P <: js.Object, A]  =
-    GenericJsComponentC[P, CtorType.PropsAndChildren, Unit, A]
-  type GenericComponentPA[P <: js.Object, A]  = GenericJsComponentA[P, CtorType.Props, Unit, A]
-  type GenericComponentPAC[P <: js.Object, A] =
-    GenericJsComponentAC[P, CtorType.PropsAndChildren, Unit, A]
-
-  type GenericComponentPF[P <: js.Object, F <: js.Object]      =
-    GenericJsComponentF[P, CtorType.Props, Unit, F]
-  type GenericComponentPCF[P <: js.Object, A, F <: js.Object]  =
-    GenericJsComponentCF[P, CtorType.PropsAndChildren, Unit, A, F]
-  type GenericComponentPAF[P <: js.Object, A, F <: js.Object]  =
-    GenericJsComponentAF[P, CtorType.Props, Unit, A, F]
-  type GenericComponentPACF[P <: js.Object, A, F <: js.Object] =
-    GenericJsComponentACF[P, CtorType.PropsAndChildren, Unit, A, F]
-
-  implicit class GenericFnComponentPCOps[P <: js.Object, A](val c: GenericFnComponentPC[P, A])
-      extends AnyVal {
-    def apply(children: VdomNode*): A = c.withChildren(children)
-  }
-
-  implicit class GenericFnComponentPAOps[P <: js.Object, A](val c: GenericFnComponentPA[P, A])
-      extends AnyVal {
-    def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
-  }
-
-  implicit class GenericFnComponentPACOps[P <: js.Object, A](val c: GenericFnComponentPAC[P, A])
-      extends AnyVal {
-    def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
-  }
-
-  implicit class GenericComponentPCOps[P <: js.Object, A](val c: GenericComponentPC[P, A])
-      extends AnyVal {
-    def apply(children: VdomNode*): A = c.withChildren(children)
-  }
-
-  implicit class GenericComponentPAOps[P <: js.Object, A](val c: GenericComponentPA[P, A])
-      extends AnyVal {
-    def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
-  }
-
-  implicit class GenericComponentPACOps[P <: js.Object, A](val c: GenericComponentPAC[P, A])
-      extends AnyVal {
-    def apply(modifiers: TagMod*): A = c.addModifiers(modifiers)
-  }
+  m.asInstanceOf[js.Object]
 }
+
+private def filterProps[P <: js.Object](p: P, name: String, names: String*): P = {
+  val o = js.Dictionary.empty[js.Any]
+  val c = p.asInstanceOf[js.Dictionary[js.Any]]
+  for {
+    k <- js.Object.getOwnPropertyNames(p) if name != k && !names.contains(k)
+    v <- c.get(k)
+  } yield o(k) = v
+  o.asInstanceOf[P]
+}
+
+val Style = style.Style
+val Css   = style.Css
+type Style = style.Style
+type Css   = style.Css
+
+// Begin JS Components
+type RenderFn[P]                              = Generic.Unmounted[P, Unit]
+type Render[P <: js.Object]                   = Unmounted[P, Null]
+type RenderF[P <: js.Object, F <: js.Object]  = UnmountedWithFacade[P, Null, F]
+type RenderFnC[P]                             = CtorType.ChildrenArgs => RenderFn[P]
+type RenderC[P <: js.Object]                  = CtorType.ChildrenArgs => Render[P]
+type RenderCF[P <: js.Object, F <: js.Object] = CtorType.ChildrenArgs => RenderF[P, F]
+
+type GenericFnComponentP[P <: js.Object]      = GenericFnComponent[P, CtorType.Props, Unit]
+type GenericFnComponentPC[P <: js.Object, A]  =
+  GenericFnComponentC[P, CtorType.PropsAndChildren, Unit, A]
+type GenericFnComponentPA[P <: js.Object, A]  = GenericFnComponentA[P, CtorType.Props, Unit, A]
+type GenericFnComponentPAC[P <: js.Object, A] =
+  GenericFnComponentAC[P, CtorType.PropsAndChildren, Unit, A]
+
+type GenericComponentP[P <: js.Object]      = GenericJsComponent[P, CtorType.Props, Unit]
+type GenericComponentPC[P <: js.Object, A]  =
+  GenericJsComponentC[P, CtorType.PropsAndChildren, Unit, A]
+type GenericComponentPA[P <: js.Object, A]  = GenericJsComponentA[P, CtorType.Props, Unit, A]
+type GenericComponentPAC[P <: js.Object, A] =
+  GenericJsComponentAC[P, CtorType.PropsAndChildren, Unit, A]
+
+type GenericComponentPF[P <: js.Object, F <: js.Object]      =
+  GenericJsComponentF[P, CtorType.Props, Unit, F]
+type GenericComponentPCF[P <: js.Object, A, F <: js.Object]  =
+  GenericJsComponentCF[P, CtorType.PropsAndChildren, Unit, A, F]
+type GenericComponentPAF[P <: js.Object, A, F <: js.Object]  =
+  GenericJsComponentAF[P, CtorType.Props, Unit, A, F]
+type GenericComponentPACF[P <: js.Object, A, F <: js.Object] =
+  GenericJsComponentACF[P, CtorType.PropsAndChildren, Unit, A, F]
+
+export syntax.all.{*, given}

--- a/common/src/main/scala/lucuma/react/common/size.scala
+++ b/common/src/main/scala/lucuma/react/common/size.scala
@@ -3,24 +3,20 @@
 
 package lucuma.react.common
 
-import cats._
+import cats.*
 
 import scala.scalajs.js
 
 @js.native
-trait Size extends js.Object {
+trait Size extends js.Object:
   var height: Double
   var width: Double
-}
 
-object Size {
-  def apply(height: Double, width: Double): Size = {
+object Size:
+  def apply(height: Double, width: Double): Size =
     val p = (new js.Object).asInstanceOf[Size]
     p.height = height
     p.width = width
     p
-  }
 
   given Eq[Size] = Eq.by(x => (x.width, x.height))
-
-}

--- a/common/src/main/scala/lucuma/react/common/style/package.scala
+++ b/common/src/main/scala/lucuma/react/common/style/package.scala
@@ -9,7 +9,6 @@ import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^.*
 
 import scala.annotation.targetName
-import scala.language.implicitConversions
 import scala.scalajs.js
 
 import js.JSConverters.*

--- a/common/src/main/scala/lucuma/react/common/syntax/package.scala
+++ b/common/src/main/scala/lucuma/react/common/syntax/package.scala
@@ -4,263 +4,57 @@
 package lucuma.react.common.syntax
 
 import japgolly.scalajs.react.Callback
-import japgolly.scalajs.react.vdom.VdomNode
 import lucuma.react.common.*
 
-import scala.language.implicitConversions
+import scala.annotation.targetName
 import scala.scalajs.js
 
 trait EnumValueSyntax {
-  extension [A](a: A)(using ev: EnumValue[A]) inline def toJs: String = ev.value(a)
+  // These can't be extension methods because their signatures clash.
+  // extension [A](a: A)(using ev: EnumValue[A]) inline def toJs: String = ev.value(a)
 
-  implicit def syntaxEnumValueUndef[A: EnumValue](a: js.UndefOr[A]): EnumValueUndefOps[A] =
-    new EnumValueUndefOps(a)
+  given [A: EnumValue]: Conversion[A, EnumValueOps[A]] =
+    new EnumValueOps(_)
 
-  implicit def syntaxEnumValueB[A: EnumValueB](a: A): EnumValueOpsB[A] =
-    new EnumValueOpsB(a)
+  given [A: EnumValue]: Conversion[js.UndefOr[A], EnumValueUndefOps[A]] =
+    new EnumValueUndefOps(_)
 
-  implicit def syntaxEnumValueUndefB[A: EnumValueB](a: js.UndefOr[A]): EnumValueUndefOpsB[A] =
-    new EnumValueUndefOpsB(a)
+  given [A: EnumValueB]: Conversion[A, EnumValueOpsB[A]] =
+    new EnumValueOpsB(_)
+
+  given [A: EnumValueB]: Conversion[js.UndefOr[A], EnumValueUndefOpsB[A]] =
+    new EnumValueUndefOpsB(_)
 }
 
-final class EnumValueUndefOps[A](a: js.UndefOr[A])(implicit ev: EnumValue[A]) {
-  def toJs: js.UndefOr[String] =
-    a.map(ev.value)
-}
+final class EnumValueOps[A] protected[syntax] (a: A)(using ev: EnumValue[A]):
+  inline def toJs: String = ev.value(a)
 
-final class EnumValueOpsB[A](a: A)(implicit ev: EnumValueB[A]) {
+final class EnumValueUndefOps[A] protected[syntax] (a: js.UndefOr[A])(using ev: EnumValue[A]):
+  def toJs: js.UndefOr[String] = a.map(ev.value)
+
+final class EnumValueOpsB[A] protected[syntax] (a: A)(using ev: EnumValueB[A]):
   def toJs: Boolean | String = ev.value(a)
-}
 
-final class EnumValueUndefOpsB[A](a: js.UndefOr[A])(implicit ev: EnumValueB[A]) {
-  def toJs: js.UndefOr[Boolean | String] =
-    a.map(ev.value)
-}
-
-trait CallbackPairSyntax extends CallbackSyntax {
-  implicit def syntaxCallbackPair1[A](
-    a: (js.UndefOr[A => Callback], js.UndefOr[Callback])
-  ): CallbackPairOps1[A] =
-    new CallbackPairOps1(a._1, a._2)
-
-  implicit def syntaxCallbackPair2[A, B](
-    a: (js.UndefOr[(A, B) => Callback], js.UndefOr[Callback])
-  ): CallbackPairOps2[A, B] =
-    new CallbackPairOps2(a._1, a._2)
-}
+final class EnumValueUndefOpsB[A] protected[syntax] (a: js.UndefOr[A])(using ev: EnumValueB[A]):
+  def toJs: js.UndefOr[Boolean | String] = a.map(ev.value)
 
 // Some useful conversions
-final class CallbackOps(val c: js.UndefOr[Callback]) extends AnyVal {
-  def toJs: js.UndefOr[js.Function0[Unit]]              = c.map(x => () => x.runNow())
-  def toJs1[A]: js.UndefOr[js.Function1[A, Unit]]       = c.map(x => (_: A) => x.runNow())
-  def toJs2[A, B]: js.UndefOr[js.Function2[A, B, Unit]] = c.map(x => (_: A, _: B) => x.runNow())
-}
-
-final class CallbackOps1[A](val c: js.UndefOr[A => Callback]) extends AnyVal {
-  def toJs: js.UndefOr[js.Function1[A, Unit]] = c.map(x => (a: A) => x(a).runNow())
-}
-
-final class CallbackOps2[A, B](val c: js.UndefOr[(A, B) => Callback]) extends AnyVal {
-  def toJs: js.UndefOr[js.Function2[A, B, Unit]] = c.map(x => (a: A, b: B) => x(a, b).runNow())
-}
-
 trait CallbackSyntax {
-  implicit def callbackOps(c: js.UndefOr[Callback]): CallbackOps =
-    new CallbackOps(c)
 
-  implicit def callbackOps1[A](c: js.UndefOr[A => Callback]): CallbackOps1[A] =
-    new CallbackOps1(c)
+  extension (c: js.UndefOr[Callback])
+    def toJs: js.UndefOr[js.Function0[Unit]] = c.map(x => () => x.runNow())
 
-  implicit def callbackOps2[A, B](c: js.UndefOr[(A, B) => Callback]): CallbackOps2[A, B] =
-    new CallbackOps2(c)
+  extension [A](c: js.UndefOr[A => Callback])
+    @targetName("toJs1")
+    def toJs: js.UndefOr[js.Function1[A, Unit]] = c.map(x => (a: A) => x(a).runNow())
 
-  final class CallbackPairOps1[A](a: js.UndefOr[A => Callback], b: js.UndefOr[Callback]) {
-    def toJs: js.UndefOr[js.Function1[A, Unit]] = a.toJs.orElse(b.toJs1)
-  }
-
-  final class CallbackPairOps2[A, B](a: js.UndefOr[(A, B) => Callback], b: js.UndefOr[Callback]) {
-    def toJs: js.UndefOr[js.Function2[A, B, Unit]] = a.toJs.orElse(b.toJs2)
-  }
+  extension [A, B](c: js.UndefOr[(A, B) => Callback])
+    @targetName("toJs2")
+    def toJs: js.UndefOr[js.Function2[A, B, Unit]] = c.map(x => (a: A, b: B) => x(a, b).runNow())
 }
 
-trait RenderSyntax {
-  // Render(Fn) conversions
-  implicit def GenericFnComponentP2RenderFn[P <: js.Object](
-    p: GenericFnComponentP[P]
-  ): RenderFn[P] =
-    p.render
-
-  implicit def GenericFnComponentPC2RenderFn[P <: js.Object](
-    p: GenericFnComponentPC[P, ?]
-  ): RenderFn[P] =
-    p.render
-
-  implicit def GenericFnComponentPA2RenderFn[P <: js.Object](
-    p: GenericFnComponentPA[P, ?]
-  ): RenderFn[P] =
-    p.render
-
-  implicit def GenericFnComponentPAC2RenderFn[P <: js.Object](
-    p: GenericFnComponentPAC[P, ?]
-  ): RenderFn[P] =
-    p.render
-
-  // Render conversions
-  implicit def GenericComponentP2Render[P <: js.Object](
-    p: GenericComponentP[P]
-  ): Render[P] =
-    p.render
-
-  implicit def GenericComponentPC2Render[P <: js.Object](
-    p: GenericComponentPC[P, ?]
-  ): Render[P] =
-    p.render
-
-  implicit def GenericComponentPA2Render[P <: js.Object](
-    p: GenericComponentPA[P, ?]
-  ): Render[P] =
-    p.render
-
-  implicit def GenericComponentPAC2Render[P <: js.Object](
-    p: GenericComponentPAC[P, ?]
-  ): Render[P] =
-    p.render
-}
-
-trait VdomSyntax {
-  // FnComponent to VdomNode conversions
-  implicit def GenericFnComponentP2VdomNode[P <: js.Object](
-    p: GenericFnComponentP[P]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericFnComponentPC2VdomNode[P <: js.Object](
-    p: GenericFnComponentPC[P, ?]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericFnComponentPA2VdomNode[P <: js.Object](
-    p: GenericFnComponentPA[P, ?]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericFnComponentPAC2VdomNode[P <: js.Object](
-    p: GenericFnComponentPAC[P, ?]
-  ): VdomNode =
-    p.render
-
-  // Component 2 VdomNode conversions
-  implicit def GenericComponentP2VdomNode[P <: js.Object](
-    p: GenericComponentP[P]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericComponentPC2VdomNode[P <: js.Object](
-    p: GenericComponentPC[P, ?]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericComponentPA2VdomNode[P <: js.Object](
-    p: GenericComponentPA[P, ?]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericComponentPAC2VdomNode[P <: js.Object](
-    p: GenericComponentPAC[P, ?]
-  ): VdomNode =
-    p.render
-
-  // Facade component 2 VdomNode conversions
-  implicit def GenericComponentPF2VdomNode[P <: js.Object, F <: js.Object](
-    p: GenericComponentPF[P, F]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericComponentPCF2VdomNode[P <: js.Object, F <: js.Object](
-    p: GenericComponentPCF[P, ?, F]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericComponentPAF2VdomNode[P <: js.Object, F <: js.Object](
-    p: GenericComponentPAF[P, ?, F]
-  ): VdomNode =
-    p.render
-
-  implicit def GenericComponentPACF2VdomNode[P <: js.Object, F <: js.Object](
-    p: GenericComponentPACF[P, ?, F]
-  ): VdomNode =
-    p.render
-
-  // FnComponent to js.UndefOr[VdomNode] conversions
-  implicit def GenericFnComponentP2UndefVdomNode[P <: js.Object](
-    p: GenericFnComponentP[P]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericFnComponentPC2UndefVdomNode[P <: js.Object](
-    p: GenericFnComponentPC[P, ?]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericFnComponentPA2UndefVdomNode[P <: js.Object](
-    p: GenericFnComponentPA[P, ?]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericFnComponentPAC2UndefVdomNode[P <: js.Object](
-    p: GenericFnComponentPAC[P, ?]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  // Component to js.UndefOr[VdomNode] conversions
-  implicit def GenericComponentP2UndefVdomNode[P <: js.Object](
-    p: GenericComponentP[P]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericComponentPC2UndefVdomNode[P <: js.Object](
-    p: GenericComponentPC[P, ?]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericComponentPA2UndefVdomNode[P <: js.Object](
-    p: GenericComponentPA[P, ?]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericComponentPAC2UndefVdomNode[P <: js.Object](
-    p: GenericComponentPAC[P, ?]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  // Facade Component to js.UndefOr[VdomNode] conversions
-  implicit def GenericComponentPF2UndefVdomNode[P <: js.Object, F <: js.Object](
-    p: GenericComponentPF[P, F]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericComponentPCF2UndefVdomNode[P <: js.Object, F <: js.Object](
-    p: GenericComponentPCF[P, ?, F]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericComponentPAF2UndefVdomNode[P <: js.Object, F <: js.Object](
-    p: GenericComponentPAF[P, ?, F]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  implicit def GenericComponentPACF2UndefVdomNode[P <: js.Object, F <: js.Object](
-    p: GenericComponentPACF[P, ?, F]
-  ): js.UndefOr[VdomNode] =
-    p.render: VdomNode
-
-  // End VdomNode conversions
-}
+trait AllSyntax extends EnumValueSyntax with CallbackSyntax
 
 object all       extends AllSyntax
-object vdom      extends VdomSyntax
-object render    extends RenderSyntax
 object enumValue extends EnumValueSyntax
-object callback  extends CallbackSyntax with CallbackPairSyntax
-
-trait AllSyntax extends EnumValueSyntax with CallbackPairSyntax with RenderSyntax with VdomSyntax
+object callback  extends CallbackSyntax

--- a/common/src/test/scala/lucuma/react/common/arb/ArbSize.scala
+++ b/common/src/test/scala/lucuma/react/common/arb/ArbSize.scala
@@ -3,21 +3,20 @@
 
 package lucuma.react.common.arb
 
-import lucuma.react.common._
+import lucuma.react.common.Size
 import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.*
 import org.scalacheck.Cogen
 
-trait ArbSize {
-  implicit val arbSize: Arbitrary[Size] = Arbitrary {
-    for {
+trait ArbSize:
+  given Arbitrary[Size] = Arbitrary:
+    for
       w <- arbitrary[Double]
       h <- arbitrary[Double]
-    } yield Size(w, h)
-  }
+    yield Size(w, h)
 
-  implicit val cogenSize: Cogen[Size] =
-    Cogen[(Double, Double)].contramap(x => (x.width, x.height))
-}
+  given Cogen[Size] =
+    Cogen[(Double, Double)].contramap: x =>
+      (x.width, x.height)
 
 object ArbSize extends ArbSize

--- a/common/src/test/scala/lucuma/react/common/arb/ArbStyle.scala
+++ b/common/src/test/scala/lucuma/react/common/arb/ArbStyle.scala
@@ -9,33 +9,28 @@ import org.scalacheck.Arbitrary.*
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
 
-trait ArbStyle {
-  implicit val arbStyleMember: Arbitrary[String | Int] = Arbitrary {
+trait ArbStyle:
+  given Arbitrary[String | Int] = Arbitrary:
     Gen.oneOf(Gen.posNum[Int], Gen.negNum[Int], Gen.alphaNumStr)
-  }
-  implicit val cogenStyleMember: Cogen[String | Int]   =
-    Cogen[Either[String, Int]].contramap { x =>
-      (x: Any) match {
+
+  given Cogen[String | Int] =
+    Cogen[Either[String, Int]].contramap: x =>
+      (x: Any) match
         case a: String => Left(a)
         case a: Int    => Right(a)
         case _         => sys.error("Unsupported type")
-      }
-    }
-  implicit val arbStyle: Arbitrary[Style]              = Arbitrary {
+
+  given Arbitrary[Style] = Arbitrary:
     arbitrary[Map[String, String | Int]].map(m => Style(m))
-  }
-  implicit val cogenStyle: Cogen[Style]                =
+
+  given Cogen[Style] =
     Cogen[List[(String, String | Int)]].contramap(_.value.toList)
 
-  implicit val arbGStyle: Arbitrary[Css] = Arbitrary {
-    for {
-      cs <- Gen.listOf(Gen.alphaLowerStr)
-    } yield Css(cs)
-  }
+  given Arbitrary[Css] = Arbitrary:
+    for cs <- Gen.listOf(Gen.alphaLowerStr)
+    yield Css(cs)
 
-  implicit val gStyleCogen: Cogen[Css] =
+  given Cogen[Css] =
     Cogen[String].contramap(_.htmlClass)
-
-}
 
 object ArbStyle extends ArbStyle

--- a/common/src/test/scala/lucuma/react/common/arb/package.scala
+++ b/common/src/test/scala/lucuma/react/common/arb/package.scala
@@ -1,6 +1,8 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.react.common
+package lucuma.react.common.arb
 
-package object arb extends ArbStyle with ArbSize
+object all:
+  export ArbSize.given
+  export ArbStyle.given

--- a/common/src/test/scala/lucuma/react/common/givens/ReactCatsSuite.scala
+++ b/common/src/test/scala/lucuma/react/common/givens/ReactCatsSuite.scala
@@ -1,18 +1,17 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.react.common.implicits
+package lucuma.react.common.givens
 
-import cats.kernel.laws.discipline._
-import lucuma.react.common._
-import lucuma.react.common.arb._
-import munit._
-import org.scalacheck.Arbitrary._
+import cats.kernel.laws.discipline.*
+import lucuma.react.common.*
+import lucuma.react.common.arb.all.given
+import munit.*
+import org.scalacheck.Arbitrary.*
 
-class StyleSuite extends DisciplineSuite {
+class StyleSuite extends DisciplineSuite:
   checkAll("Eq[Style]", EqTests[Style].eqv)
   checkAll("Order[Css]", OrderTests[Css].eqv)
   checkAll("Eq[Size]", EqTests[Size].eqv)
   checkAll("Monoid[Css]", MonoidTests[Css].monoid)
   checkAll("Monoid[Style]", MonoidTests[Style].monoid)
-}

--- a/draggable/src/main/scala/lucuma/react/draggable/Draggable.scala
+++ b/draggable/src/main/scala/lucuma/react/draggable/Draggable.scala
@@ -9,10 +9,11 @@ import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.Children
 import japgolly.scalajs.react.JsComponent
 import japgolly.scalajs.react.vdom.VdomNode
-import lucuma.react.common._
+import lucuma.react.common.given
 import org.scalajs.dom.MouseEvent
 import org.scalajs.dom.html.{Element => HTMLElement}
 
+import scala.language.implicitConversions
 import scala.scalajs.js
 
 import js.annotation.JSImport

--- a/draggable/src/main/scala/lucuma/react/draggable/package.scala
+++ b/draggable/src/main/scala/lucuma/react/draggable/package.scala
@@ -17,7 +17,7 @@ package draggable {
   sealed trait Axis
 
   object Axis {
-    implicit val enumValue: EnumValue[Axis] = EnumValue.toLowerCaseString
+    given EnumValue[Axis] = EnumValue.toLowerCaseString
 
     case object Both extends Axis
     case object X    extends Axis

--- a/floatingui/src/main/scala/lucuma/react/floatingui/package.scala
+++ b/floatingui/src/main/scala/lucuma/react/floatingui/package.scala
@@ -9,7 +9,6 @@ import japgolly.scalajs.react.facade.React
 import japgolly.scalajs.react.vdom.TopNode
 import lucuma.react.common.EnumValue
 import lucuma.react.common.syntax.callback.*
-import lucuma.react.common.syntax.enumValue.*
 import org.scalajs.dom
 import org.scalajs.dom.html
 

--- a/floatingui/src/main/scala/lucuma/react/floatingui/syntax.scala
+++ b/floatingui/src/main/scala/lucuma/react/floatingui/syntax.scala
@@ -5,8 +5,9 @@ package lucuma.react.floatingui.syntax
 
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
-import lucuma.react.common.*
 import lucuma.react.floatingui.*
+
+import scala.language.implicitConversions // This shouldn't be necessary, but it is.
 
 extension (tag: VdomTag)
   def withTooltip(

--- a/floatingui/src/test/scala/react/floatingui/TooltipSuite.scala
+++ b/floatingui/src/test/scala/react/floatingui/TooltipSuite.scala
@@ -5,7 +5,8 @@ package lucuma.react.floatingui
 
 import japgolly.scalajs.react.vdom.html_<^.{< => <<, *}
 import lucuma.react.common.TestUtils
-import lucuma.react.common.fnProps2Component
+
+import scala.language.implicitConversions // This shouldn't be necessary, but it is.
 
 class TooltipSuite extends munit.FunSuite with TestUtils {
   test("render") {

--- a/grid-layout-demo/src/main/scala/lucuma/react/gridlayout/Demo.scala
+++ b/grid-layout-demo/src/main/scala/lucuma/react/gridlayout/Demo.scala
@@ -12,6 +12,7 @@ import lucuma.react.resizeDetector._
 import lucuma.react.resizeDetector.hooks._
 import org.scalajs.dom
 
+import scala.language.implicitConversions
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 

--- a/grid-layout/src/main/scala/lucuma/react/gridlayout/BaseProps.scala
+++ b/grid-layout/src/main/scala/lucuma/react/gridlayout/BaseProps.scala
@@ -6,11 +6,12 @@ package lucuma.react
 package gridlayout
 
 import japgolly.scalajs.react.Callback
-import lucuma.react.common._
+import lucuma.react.common.{*, given}
 import org.scalajs.dom.Event
 import org.scalajs.dom.MouseEvent
 import org.scalajs.dom.html.{Element => HTMLElement}
 
+import scala.language.implicitConversions
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 

--- a/grid-layout/src/test/scala/react/gridlayout/PackageTests.scala
+++ b/grid-layout/src/test/scala/react/gridlayout/PackageTests.scala
@@ -3,10 +3,12 @@
 
 package lucuma.react.gridlayout
 
-import japgolly.scalajs.react.test._
-import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.test.*
+import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.syntax.all.*
-import utest._
+import utest.*
+
+import scala.language.implicitConversions
 
 object PackageTests extends TestSuite {
 

--- a/resize-detector/src/main/scala/lucuma/react/resizeDetector/ResizeDetector.scala
+++ b/resize-detector/src/main/scala/lucuma/react/resizeDetector/ResizeDetector.scala
@@ -5,7 +5,7 @@ package lucuma.react.resizeDetector
 
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
-import lucuma.react.common.*
+import lucuma.react.common.{*, given}
 import org.scalajs.dom.html
 
 import scalajs.js

--- a/resize-detector/src/main/scala/lucuma/react/resizeDetector/hooks.scala
+++ b/resize-detector/src/main/scala/lucuma/react/resizeDetector/hooks.scala
@@ -4,7 +4,7 @@
 package lucuma.react.resizeDetector
 
 import japgolly.scalajs.react.*
-import lucuma.react.common.*
+import lucuma.react.common.given
 import lucuma.react.resizeDetector.ResizeDetector.*
 import org.scalajs.dom.html
 

--- a/test/src/main/scala/lucuma/react/common/TestUtils.scala
+++ b/test/src/main/scala/lucuma/react/common/TestUtils.scala
@@ -7,36 +7,35 @@ import japgolly.scalajs.react.ReactDOMServer
 import japgolly.scalajs.react.facade.React
 import japgolly.scalajs.react.vdom.TagOf
 import japgolly.scalajs.react.vdom.TopNode
-import japgolly.scalajs.react.vdom.html_<^._
-import munit.Assertions._
+import japgolly.scalajs.react.vdom.html_<^.*
+import munit.Assertions.*
 import org.scalajs.dom.Element
 
-trait TestUtils {
+trait TestUtils:
 
   def assertRender(e: VdomElement, expected: String, scrub: String = ""): Unit =
     assertRender(e.rawElement, expected, scrub)
 
-  def assertRender(e: React.Element, expected: String, scrub: String): Unit = {
+  def assertRender(e: React.Element, expected: String, scrub: String): Unit =
     val rendered: String = ReactDOMServer.raw.renderToStaticMarkup(e)
-    assertEquals(rendered.replaceAll(scrub, "").trim.replaceAll("\n", ""),
-                 expected.replaceAll(scrub, "").trim.replaceAll("\n", "")
+
+    assertEquals(
+      rendered.replaceAll(scrub, "").trim.replaceAll("\n", ""),
+      expected.replaceAll(scrub, "").trim.replaceAll("\n", "")
     )
-  }
 
   def assertRender(e: React.Node, expected: String): Unit =
     assertRenderNode(Some(e), expected)
 
   def assertRenderNode[N <: TopNode](e: Option[React.Node], expected: String): Unit =
-    e.map(x => HtmlTag("div").apply(VdomNode(x))) match {
+    e.map(x => HtmlTag("div").apply(VdomNode(x))) match
       case Some(e) => assertRender(e.rawElement, expected)
       case _       => assert(false)
-    }
 
   def assertRender[N <: TopNode](e: Option[TagOf[N]], expected: String): Unit =
-    e match {
+    e match
       case Some(e) => assertRender(e.rawElement, expected)
       case _       => assert(false)
-    }
 
   def assertOuterHTML(node: Element, expect: String): Unit =
     assertEquals(scrubReactHtml(node.outerHTML), expect)
@@ -46,6 +45,5 @@ trait TestUtils {
 
   def scrubReactHtml(html: String): String =
     reactRubbish.replaceAllIn(html, "")
-}
 
 object TestUtils extends TestUtils

--- a/test/src/test/scala/react/common/CommonSuite.scala
+++ b/test/src/test/scala/react/common/CommonSuite.scala
@@ -3,58 +3,56 @@
 
 package lucuma.react.common
 
-import cats.syntax.all._
-import lucuma.react.common.implicits.given
+import cats.syntax.all.*
+import lucuma.react.common.givens.given
 
 import scala.scalajs.js
 
-class CommonSuite extends munit.FunSuite with TestUtils {
-  test("merge") {
+class CommonSuite extends munit.FunSuite with TestUtils:
+  test("merge"):
     val a: js.Object = js.Dynamic.literal(foo = 42, bar = "foobar")
     val b            = js.Object()
     val m            = merge(a, b)
     assert(a === m)
-  }
-  test("merge1") {
+
+  test("merge1"):
     val a: js.Object = js.Dynamic.literal(foo = 42, bar = "foobar")
     val b: js.Object = js.Dynamic.literal(c = 15)
     val c: js.Object = js.Dynamic.literal(c = 15, foo = 42, bar = "foobar")
     val m            = merge(a, b)
     assert(c === m)
-  }
-  test("merge1") {
+
+  test("merge1"):
     val a: js.Object = js.Dynamic.literal(foo = 42, bar = "foobar")
     val b: js.Object = js.Dynamic.literal(foo = 15)
     val c: js.Object = js.Dynamic.literal(foo = 15, bar = "foobar")
     val m            = merge(a, b)
     assert(c === m)
-  }
-  test("style") {
+
+  test("style"):
     val a: js.Object = js.Dynamic.literal(height = 42, background = "black")
     val b: js.Object = Style(Map("height" -> 42, "background" -> "black")).toJsObject
     assert(a === b)
-  }
-  test("cssMix") {
+
+  test("cssMix"):
     val className: js.UndefOr[String] = "header"
     val clz                           = Css("abc")
     val clz2                          = Css(List("c1", "c2"))
     val clazz: js.UndefOr[Css]        = clz |+| clz2
     assert((className, clazz).cssToJs === "header abc c1 c2")
-  }
-  test("cssMix1") {
+
+  test("cssMix1"):
     val className: js.UndefOr[String] = js.undefined
     val clazz: js.UndefOr[Css]        = js.undefined
     assert(!(className, clazz).cssToJs.isDefined)
-  }
-  test("cssMix2") {
+
+  test("cssMix2"):
     val className: js.UndefOr[String] = "header"
     val clazz: js.UndefOr[Css]        = js.undefined
     assert((className, clazz).cssToJs === "header")
-  }
-  test("cssMix3") {
+
+  test("cssMix3"):
     val className: js.UndefOr[String] = "header"
     val clz                           = Css("abc")
     val clz2                          = Css(List("c1", "c2"))
     assert((className, (clz |+| clz2): js.UndefOr[Css]).cssToJs === "header abc c1 c2")
-  }
-}

--- a/test/src/test/scala/react/common/ReactFnPropsSuite.scala
+++ b/test/src/test/scala/react/common/ReactFnPropsSuite.scala
@@ -3,18 +3,17 @@
 
 package lucuma.react.common
 
-import japgolly.scalajs.react._
+import japgolly.scalajs.react.*
 import japgolly.scalajs.react.internal.FacadeExports
-import japgolly.scalajs.react.test._
-import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.test.*
+import japgolly.scalajs.react.vdom.html_<^.*
 
-class ReactFnPropsSuite extends munit.FunSuite {
-
+class ReactFnPropsSuite extends munit.FunSuite:
   case class Props() extends ReactFnProps(fnPropsComponent)
 
   val fnPropsComponent = ScalaFnComponent[Props](_ => <.div)
 
-  test("props") {
+  test("props"):
     val p        = Props()
     val u        = p.toUnmounted
     val key      = u.key
@@ -27,9 +26,8 @@ class ReactFnPropsSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
 
-  test("props.withKey") {
+  test("props.withKey"):
     val p        = Props().withKey("key")
     val u        = p.toUnmounted
     val key      = u.key
@@ -42,5 +40,3 @@ class ReactFnPropsSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
-}

--- a/test/src/test/scala/react/common/ReactFnPropsWithChildrenSuite.scala
+++ b/test/src/test/scala/react/common/ReactFnPropsWithChildrenSuite.scala
@@ -8,14 +8,13 @@ import japgolly.scalajs.react.internal.FacadeExports
 import japgolly.scalajs.react.test.*
 import japgolly.scalajs.react.vdom.html_<^.*
 
-class ReactFnPropsWithChildrenSuite extends munit.FunSuite {
-
+class ReactFnPropsWithChildrenSuite extends munit.FunSuite:
   case class PropsWithChildren() extends ReactFnPropsWithChildren(fnPropsWithChildrenComponent)
 
   val fnPropsWithChildrenComponent =
     ScalaFnComponent.withChildren[PropsWithChildren]((_, c) => <.div(c))
 
-  test("propsWithChildren") {
+  test("propsWithChildren"):
     val p        = PropsWithChildren()
     val u        = p(<.div)
     val key      = u.key
@@ -33,9 +32,8 @@ class ReactFnPropsWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
 
-  test("propsWithChildren.withKey") {
+  test("propsWithChildren.withKey"):
     val p        = PropsWithChildren().withKey("key")
     val u        = p(<.div)
     val key      = u.key
@@ -52,5 +50,3 @@ class ReactFnPropsWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
-}

--- a/test/src/test/scala/react/common/ReactPropsForwardRefSuite.scala
+++ b/test/src/test/scala/react/common/ReactPropsForwardRefSuite.scala
@@ -11,8 +11,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 
 import scala.language.implicitConversions
 
-class ReactPropsForwardRefSuite extends munit.FunSuite {
-
+class ReactPropsForwardRefSuite extends munit.FunSuite:
   val forwardee = ScalaComponent
     .builder[Unit]("Forwardee")
     .render(_ => <.div)
@@ -25,7 +24,7 @@ class ReactPropsForwardRefSuite extends munit.FunSuite {
       forwardee.withOptionalRef(ref)()
     )
 
-  test("props") {
+  test("props"):
     val p        = Props()
     val u        = p.toUnmounted
     val key      = u.key
@@ -40,9 +39,8 @@ class ReactPropsForwardRefSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
 
-  test("props.withKey") {
+  test("props.withKey"):
     val p        = Props().withKey("key")
     val u        = p.toUnmounted
     val key      = u.key
@@ -57,9 +55,8 @@ class ReactPropsForwardRefSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
 
-  test("props.withRef") {
+  test("props.withRef"):
     val p        = Props()
     val r        = Ref.toScalaComponent(forwardee)
     val pr       = p.withRef(r)
@@ -76,9 +73,8 @@ class ReactPropsForwardRefSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
 
-  test("props.withRef.withKey") {
+  test("props.withRef.withKey"):
     val p        = Props()
     val r        = Ref.toScalaComponent(forwardee)
     val pr       = p.withRef(r).withKey("key")
@@ -95,5 +91,3 @@ class ReactPropsForwardRefSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
-}

--- a/test/src/test/scala/react/common/ReactPropsForwardRefWithChildrenSuite.scala
+++ b/test/src/test/scala/react/common/ReactPropsForwardRefWithChildrenSuite.scala
@@ -11,8 +11,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 
 import scala.language.implicitConversions
 
-class ReactPropsForwardRefWithChildrenSuite extends munit.FunSuite {
-
+class ReactPropsForwardRefWithChildrenSuite extends munit.FunSuite:
   val forwardee = ScalaComponent
     .builder[Unit]("Forwardee")
     .render_C(c => <.div(c))
@@ -26,7 +25,7 @@ class ReactPropsForwardRefWithChildrenSuite extends munit.FunSuite {
       .toScalaComponent(forwardee)
       .withChildren[PropsWithChildren]((_, c, ref) => forwardee.withOptionalRef(ref)(c))
 
-  test("propsWithChildren") {
+  test("propsWithChildren"):
     val p        = PropsWithChildren()
     val u        = p(<.div)
     val key      = u.key
@@ -45,9 +44,8 @@ class ReactPropsForwardRefWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
 
-  test("propsWithChildren.withKey") {
+  test("propsWithChildren.withKey"):
     val p        = PropsWithChildren().withKey("key")
     val u        = p(<.div)
     val key      = u.key
@@ -66,9 +64,8 @@ class ReactPropsForwardRefWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
 
-  test("propsWithChildren.withRef") {
+  test("propsWithChildren.withRef"):
     val p        = PropsWithChildren()
     val r        = Ref.toScalaComponent(forwardee)
     val pr       = p.withRef(r)
@@ -89,9 +86,8 @@ class ReactPropsForwardRefWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
 
-  test("propsWithChildren.withRef.withKey") {
+  test("propsWithChildren.withRef.withKey"):
     val p        = PropsWithChildren()
     val r        = Ref.toScalaComponent(forwardee)
     val pr       = p.withRef(r).withKey("key")
@@ -112,6 +108,3 @@ class ReactPropsForwardRefWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
-
-}

--- a/test/src/test/scala/react/common/ReactPropsSuite.scala
+++ b/test/src/test/scala/react/common/ReactPropsSuite.scala
@@ -3,21 +3,20 @@
 
 package lucuma.react.common
 
-import japgolly.scalajs.react._
+import japgolly.scalajs.react.*
 import japgolly.scalajs.react.facade.React.RefHandle
 import japgolly.scalajs.react.internal.FacadeExports
-import japgolly.scalajs.react.test._
-import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.test.*
+import japgolly.scalajs.react.vdom.html_<^.*
 
 import scala.language.implicitConversions
 
-class ReactPropsSuite extends munit.FunSuite {
-
+class ReactPropsSuite extends munit.FunSuite:
   case class Props() extends ReactProps(propsComponent)
 
   val propsComponent = ScalaComponent.builder[Props].render(_ => <.div).build
 
-  test("props") {
+  test("props"):
     val p        = Props()
     val u        = p.toUnmounted
     val key      = u.key
@@ -32,9 +31,8 @@ class ReactPropsSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
 
-  test("props.withKey") {
+  test("props.withKey"):
     val p        = Props().withKey("key")
     val u        = p.toUnmounted
     val key      = u.key
@@ -49,9 +47,8 @@ class ReactPropsSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
 
-  test("props.withRef") {
+  test("props.withRef"):
     val p        = Props()
     val r        = Ref.toScalaComponent(p.component)
     val pr       = p.withRef(r)
@@ -68,9 +65,8 @@ class ReactPropsSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
 
-  test("props.withRef.withKey") {
+  test("props.withRef.withKey"):
     val p        = Props()
     val r        = Ref.toScalaComponent(p.component)
     val pr       = p.withRef(r).withKey("key")
@@ -87,6 +83,3 @@ class ReactPropsSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div></div>""")
     }
-  }
-
-}

--- a/test/src/test/scala/react/common/ReactPropsWithChildrenSuite.scala
+++ b/test/src/test/scala/react/common/ReactPropsWithChildrenSuite.scala
@@ -3,22 +3,21 @@
 
 package lucuma.react.common
 
-import japgolly.scalajs.react._
+import japgolly.scalajs.react.*
 import japgolly.scalajs.react.facade.React.RefHandle
 import japgolly.scalajs.react.internal.FacadeExports
-import japgolly.scalajs.react.test._
-import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.test.*
+import japgolly.scalajs.react.vdom.html_<^.*
 
 import scala.language.implicitConversions
 
-class ReactPropsWithChildrenSuite extends munit.FunSuite {
-
+class ReactPropsWithChildrenSuite extends munit.FunSuite:
   case class PropsWithChildren() extends ReactPropsWithChildren(propsWithChildrenComponent)
 
   val propsWithChildrenComponent =
     ScalaComponent.builder[PropsWithChildren].render_C(c => <.div(c)).build
 
-  test("propsWithChildren") {
+  test("propsWithChildren"):
     val p        = PropsWithChildren()
     val u        = p(<.div)
     val key      = u.key
@@ -37,9 +36,8 @@ class ReactPropsWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
 
-  test("propsWithChildren.withKey") {
+  test("propsWithChildren.withKey"):
     val p        = PropsWithChildren().withKey("key")
     val u        = p(<.div)
     val key      = u.key
@@ -58,9 +56,8 @@ class ReactPropsWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
 
-  test("propsWithChildren.withRef") {
+  test("propsWithChildren.withRef"):
     val p        = PropsWithChildren()
     val r        = Ref.toScalaComponent(p.component)
     val pr       = p.withRef(r)
@@ -81,9 +78,8 @@ class ReactPropsWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
 
-  test("propsWithChildren.withRef.withKey") {
+  test("propsWithChildren.withRef.withKey"):
     val p        = PropsWithChildren()
     val r        = Ref.toScalaComponent(p.component)
     val pr       = p.withRef(r).withKey("key")
@@ -104,5 +100,3 @@ class ReactPropsWithChildrenSuite extends munit.FunSuite {
       val html = mountNode.outerHTML()
       assertEquals(html, """<div><div></div></div>""")
     }
-  }
-}

--- a/test/src/test/scala/react/common/StyleSuite.scala
+++ b/test/src/test/scala/react/common/StyleSuite.scala
@@ -7,35 +7,33 @@ import cats.syntax.all.*
 import lucuma.react.common.style.*
 import lucuma.react.common.style.given
 
-class StyleSuite extends munit.FunSuite with TestUtils {
-  test("style") {
+class StyleSuite extends munit.FunSuite with TestUtils:
+  test("style"):
     val a: Style = Style(Map("height" -> 42, "background" -> "black"))
     val b: Style = Style(Map("height" -> 42, "background" -> "black"))
     val c: Style = Style(Map("height" -> 42, "background" -> "black"))
     assert((a |+| b) === c)
-  }
-  test("extract") {
+
+  test("extract"):
     val a: Style = Style(Map("height" -> 42, "background" -> "black"))
     assert(a.extract[Int]("height") == 42.some)
     assert(a.extract[String]("height").isEmpty)
     assert(a.extract[String]("background") == "black".some)
-  }
-  test("remove") {
+
+  test("remove"):
     val a: Style = Style(Map("height" -> 42, "background" -> "black"))
     assert(a.remove("height").extract[String]("height").isEmpty)
-  }
-  test("when") {
+
+  test("when"):
     assert(Style(Map("height" -> 42, "background" -> "black")).when_(true).nonEmpty)
     assert(Style(Map("height" -> 42, "background" -> "black")).when_(false).isEmpty)
     assert(Css("selector").when_(true).nonEmpty)
     assert(Css("selector").when_(false).isEmpty)
-  }
-  test("unless") {
+
+  test("unless"):
     assert(Style(Map("height" -> 42, "background" -> "black")).unless_(true).isEmpty)
     assert(Style(Map("height" -> 42, "background" -> "black")).unless_(false).nonEmpty)
     assert(Css("selector").unless_(true).isEmpty)
     assert(Css("selector").unless_(false).nonEmpty)
     // With combinations
     assert((Css("selector").unless_(false) |+| Css("selector").when_(true)).nonEmpty)
-  }
-}


### PR DESCRIPTION
Modernize `common` code to Scala 3 syntax, with better redistribution of givens.

Only new functionality is `Renderable` instances for `React[Fn]Props*`, introduced in `scalajs-react` 2.2.0.