### PR TITLE
Set displayName for ReactFnProps components

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.48"
+ThisBuild / tlBaseVersion       := "0.49"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/prime-react/src/main/scala/lucuma/react/primereact/InputNumber.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/InputNumber.scala
@@ -16,6 +16,7 @@ import scalajs.js
 
 case class InputNumber(
   id:                String,
+  size:              js.UndefOr[Int] = js.undefined,
   value:             js.UndefOr[Double] = js.undefined,
   disabled:          js.UndefOr[Boolean] = js.undefined,
   placeholder:       js.UndefOr[String] = js.undefined,
@@ -51,10 +52,11 @@ object InputNumber:
     case Code   extends CurrencyDisplay("code")
     case Name   extends CurrencyDisplay("name")
 
-  def component = ScalaFnComponent[Props]: props =>
+  val component = ScalaFnComponent[Props]: props =>
     CInputNumber
       .id(props.id)
       .applyOrNot(props.value, _.value(_))
+      .applyOrNot(props.size, _.size(_))
       .applyOrNot(props.disabled, _.disabled(_))
       .applyOrNot(props.placeholder, _.placeholder(_))
       .applyOrNot(props.tooltip, _.tooltip(_))

--- a/prime-react/src/main/scala/lucuma/react/primereact/Tree.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/Tree.scala
@@ -33,11 +33,11 @@ case class Tree[A](
   onSelect:      js.UndefOr[(A, SyntheticEvent[Element]) => Callback] = js.undefined,
   dragDropScope: js.UndefOr[String] = js.undefined,
   onDragDrop:    js.UndefOr[Tree.DragDropEvent[A] => Callback] = js.undefined
-) extends ReactFnProps[Tree[A]](Tree.component)
+) extends ReactFnProps(Tree.component)
 
 object Tree {
 
-  private def component[A] = ScalaFnComponent[Tree[A]] { props =>
+  private def componentBuilder[A] = ScalaFnComponent[Tree[A]] { props =>
     CTree
       .value(props.value.map(_.toJsNode).toJSArray)
       .applyOrNot(props.selectionMode, (c, p) => c.selectionMode(p.value))
@@ -66,6 +66,8 @@ object Tree {
       .applyOrNot(props.onDragDrop, (c, p) => c.onDragDrop(e => p(Tree.DragDropEvent(e))))
 
   }
+
+  protected val component = componentBuilder[Any]
 
   enum SelectionMode(val value: single | multiple | checkbox) derives Eq:
     case Single   extends SelectionMode(single)

--- a/resize-detector-demo/src/main/scala/lucuma/react/resizeDetector/demo/HookDemo.scala
+++ b/resize-detector-demo/src/main/scala/lucuma/react/resizeDetector/demo/HookDemo.scala
@@ -15,7 +15,7 @@ case class HookDemo() extends ReactFnProps(HookDemo.component)
 object HookDemo:
   type Props = HookDemo
 
-  def component =
+  val component = 
     ScalaFnComponent
       .withHooks[Props]
       .useResizeDetector()

--- a/resize-detector/src/main/scala/lucuma/react/resizeDetector/hooks.scala
+++ b/resize-detector/src/main/scala/lucuma/react/resizeDetector/hooks.scala
@@ -13,7 +13,7 @@ import scala.scalajs.js.annotation.*
 
 @js.native
 trait UseResizeDetectorReturnJS extends DimensionsJS {
-  val ref: facade.React.RefFn[html.Element]
+  val ref: facade.React.RefHandle[html.Element]
 }
 
 sealed trait UseResizeDetectorReturn extends Dimensions {
@@ -29,7 +29,7 @@ object UseResizeDetectorReturn {
     val height = r.height.toOption.map(_.toInt)
     val width  = r.width.toOption.map(_.toInt)
     val ref    =
-      Ref.fromJs(r.ref.asInstanceOf[facade.React.RefHandle[html.Element | Null]])
+      Ref.fromJs(r.ref)
   }
 
   implicit val reusabilityUseResizeDetectorReturn: Reusability[UseResizeDetectorReturn] =


### PR DESCRIPTION
This fixes the remounting issue I've been having by letting React properly track components. In testing, this only really works if the component function is defined with `val` instead of `def`. Fortunately most places already use `val` to define components.

It should also improve performance slightly overall as this is a change for _all_ components using `ReactFnProps` that results in less rerendering/remounting of components. 

Additionally, the devtools now show component names, which is very useful! It includes the package name, which I personally like as it immediately shows what is a scala.js component.

<img width="348" alt="afbeelding" src="https://github.com/gemini-hlsw/lucuma-react/assets/10114577/9a2e1af9-0c27-4966-92da-f4d4f44385e3">


This change is _source_ compatible, but not _binary_ compatible because of the new `using` param! Downstream libs need to upgrade first before applications like explore can use it. Scala.js will give a linking error without it