### PR TITLE
Use default imports for resizable and grid-layout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.49"
+ThisBuild / tlBaseVersion       := "0.50"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/grid-layout-demo/src/main/scala/lucuma/react/gridlayout/Demo.scala
+++ b/grid-layout-demo/src/main/scala/lucuma/react/gridlayout/Demo.scala
@@ -87,6 +87,6 @@ object Demo {
       elem
     }
 
-    ReactDOMClient.createRoot(container).render(RGLDemo())
+    ReactDOMClient.createRoot(container).render(React.StrictMode(RGLDemo()))
   }
 }

--- a/grid-layout/src/main/scala/lucuma/react/gridlayout/ReactGridLayout.scala
+++ b/grid-layout/src/main/scala/lucuma/react/gridlayout/ReactGridLayout.scala
@@ -58,7 +58,8 @@ object ReactGridLayout {
 
   @js.native
   @JSImport("react-grid-layout", JSImport.Default)
-  private object RawComponent extends js.Object
+  protected[gridlayout] object RawComponent extends js.Object:
+    val Responsive: ResponsiveReactGridLayout.Responsive = js.native
 
   @js.native
   trait ReactGridLayoutProps extends BaseProps {

--- a/grid-layout/src/main/scala/lucuma/react/gridlayout/ResponsiveReactGridLayout.scala
+++ b/grid-layout/src/main/scala/lucuma/react/gridlayout/ResponsiveReactGridLayout.scala
@@ -14,8 +14,6 @@ import lucuma.react.common._
 
 import scala.scalajs.js
 
-import js.annotation.JSImport
-
 final case class ResponsiveReactGridLayout(
   width:                  Double,
   layouts:                Map[BreakpointName, (Int, Int, Layout)],
@@ -61,9 +59,11 @@ final case class ResponsiveReactGridLayout(
 
 object ResponsiveReactGridLayout {
 
+  val RawComponent = ReactGridLayout.RawComponent.Responsive
+
   @js.native
-  @JSImport("react-grid-layout", "Responsive")
-  object RawComponent extends js.Object
+  trait Responsive extends js.Object:
+    val utils: ResponsiveUtils = js.native
 
   @js.native
   trait ResponsiveReactGridLayoutProps extends BaseProps {

--- a/grid-layout/src/main/scala/lucuma/react/gridlayout/package.scala
+++ b/grid-layout/src/main/scala/lucuma/react/gridlayout/package.scala
@@ -11,10 +11,8 @@ import org.scalajs.dom.Event
 import org.scalajs.dom.MouseEvent
 import org.scalajs.dom.html.{Element => HTMLElement}
 
-import scala.annotation.nowarn
 import scala.scalajs.js
 
-import js.annotation.JSImport
 import js.JSConverters.*
 
 package object gridlayout {
@@ -50,12 +48,12 @@ package gridlayout {
    * Facade for ResponsiveUtils
    */
   @js.native
-  @JSImport("react-grid-layout", "Responsive.utils")
-  object ResponsiveUtils extends js.Object {
-    // Method from js lanf to get the breakpoint from the width
-    @nowarn
+  trait ResponsiveUtils extends js.Object {
+    // Method from js land to get the breakpoint from the width
     def getBreakpointFromWidth(breakpoints: js.Dictionary[Int], width: Double): String = js.native
   }
+
+  val ResponsiveUtils = ResponsiveReactGridLayout.RawComponent.utils
 
   opaque type BreakpointName = String
 

--- a/resizable-demo/src/main/scala/lucuma/react/draggable/demo/Demo.scala
+++ b/resizable-demo/src/main/scala/lucuma/react/draggable/demo/Demo.scala
@@ -23,7 +23,7 @@ object Demo {
       elem
     }
 
-    ReactDOMClient.createRoot(container).render(HomeComponent())
+    ReactDOMClient.createRoot(container).render(React.StrictMode(HomeComponent()))
   }
 }
 

--- a/resizable/src/main/scala/lucuma/react/resizable/Resizable.scala
+++ b/resizable/src/main/scala/lucuma/react/resizable/Resizable.scala
@@ -48,8 +48,11 @@ final case class Resizable(
 
 object Resizable {
   @js.native
-  @JSImport("react-resizable", "Resizable")
-  object RawComponent extends js.Object
+  @JSImport("react-resizable", JSImport.Default)
+  private object ReactResizable extends js.Object:
+    val Resizable: RawReactElement = js.native
+
+  val RawComponent = ReactResizable.Resizable
 
   type RawReactElement = React.Element
 


### PR DESCRIPTION
Changes the `@JSImport`'s to use `@JSImport.Default` and then call the import needed from the object.
Importing named imports doesn't work great for commonJS libraries and causes issues with Vite, because the import is transformed to `import * as $module from 'module'` and then the named import is accessed as `$module.myImport`.
