### PR TITLE
Tooltip component

### DIFF
--- a/common/src/main/scala/lucuma/react/common/style/package.scala
+++ b/common/src/main/scala/lucuma/react/common/style/package.scala
@@ -122,6 +122,8 @@ object Css:
     inline def unless_(pred: => Boolean): Css =
       when_(!pred)
 
+    def querySelector: String = css.mkString(".", ".", "")
+
   inline def apply(css: List[String]): Css = css
 
   inline def apply(css: String): Css = List(css)

--- a/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
+++ b/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
@@ -13,6 +13,8 @@ import lucuma.react.fa.FontAwesomeIcon
 import lucuma.react.fa.IconSize
 import lucuma.react.fa.LayeredIcon
 import lucuma.react.primereact.*
+import lucuma.react.primereact.tooltip.*
+import lucuma.typed.primereact.primereactStrings.popup
 
 import scala.scalajs.js.annotation.JSImport
 
@@ -418,7 +420,29 @@ object DemoControlsPanel {
                   text = "This is a message with a custom icon",
                   icon = "pi pi-bolt"
                 )
-              )
+              ),
+              <.label("Tooltip", DemoStyles.FormFieldLabel),
+              <.span(DemoStyles.FormField) {
+                val tooltipTarget = Css("tooltip-target")
+
+                React.Fragment(
+                  Tooltip(
+                    targetCss = tooltipTarget,
+                    content = "I am a tooltip",
+                    position = Tooltip.Position.Top
+                  ),
+                  <.span(tooltipTarget, "I am a <span>. Hover over me to see a tooltip."),
+                  <.br,
+                  <.br,
+                  <.span(
+                    tooltipTarget,
+                    "I am another <span>. Hover over me to see a tooltip too."
+                  ).withTooltipOptions(
+                    content = "I'm another tooltip!",
+                    position = Tooltip.Position.Bottom
+                  )
+                )
+              }
             )
           )
         )

--- a/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
+++ b/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
@@ -6,6 +6,8 @@ package lucuma.react.table.demo
 import cats.syntax.all.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
+import japgolly.scalajs.react.vdom.svg_<^.< as <<
+import japgolly.scalajs.react.vdom.svg_<^.^ as ^^
 import lucuma.react.common.*
 import lucuma.react.fa.FAIcon
 import lucuma.react.fa.FontAwesome
@@ -14,7 +16,6 @@ import lucuma.react.fa.IconSize
 import lucuma.react.fa.LayeredIcon
 import lucuma.react.primereact.*
 import lucuma.react.primereact.tooltip.*
-import lucuma.typed.primereact.primereactStrings.popup
 
 import scala.scalajs.js.annotation.JSImport
 
@@ -23,6 +24,8 @@ import scalajs.js
 case class DemoControlsPanel() extends ReactFnProps[DemoControlsPanel](DemoControlsPanel.component)
 
 object DemoControlsPanel {
+  val startOffset = VdomAttr("startOffset")
+
   object Icons:
     @js.native
     @JSImport("@fortawesome/free-solid-svg-icons", "faBan")
@@ -423,23 +426,43 @@ object DemoControlsPanel {
               ),
               <.label("Tooltip", DemoStyles.FormFieldLabel),
               <.span(DemoStyles.FormField) {
-                val tooltipTarget = Css("tooltip-target")
+                val TooltipTarget = Css("tooltip-target")
 
                 React.Fragment(
                   Tooltip(
-                    targetCss = tooltipTarget,
+                    targetCss = TooltipTarget,
                     content = "I am a tooltip",
                     position = Tooltip.Position.Top
                   ),
-                  <.span(tooltipTarget, "I am a <span>. Hover over me to see a tooltip."),
+                  <.span(TooltipTarget)("I am a <span>. Hover over me to see a tooltip."),
                   <.br,
                   <.br,
-                  <.span(
-                    tooltipTarget,
-                    "I am another <span>. Hover over me to see a tooltip too."
-                  ).withTooltipOptions(
-                    content = "I'm another tooltip!",
-                    position = Tooltip.Position.Bottom
+                  <.span(TooltipTarget)("I am another <span>. Hover over me to see a tooltip too.")
+                    .withTooltipOptions(
+                      content = "I'm another tooltip!",
+                      position = Tooltip.Position.Bottom
+                    ),
+                  <.br,
+                  <<.svg(
+                    ^.width  := "300px",
+                    ^.height := "130px",
+                    ^.xmlns  := "http://www.w3.org/2000/svg"
+                  )(
+                    <<.path(
+                      ^.id           := "lineAC",
+                      ^^.d           := "M 30 180 q 150 -250 300 0",
+                      ^^.stroke      := "blue",
+                      ^^.strokeWidth := "2",
+                      ^^.fill        := "none"
+                    ),
+                    <<.text(TooltipTarget, ^^.fill := "red", ^^.fontSize := "24px")(
+                      <<.textPath(^.href := "#lineAC", startOffset := "80")(
+                        "It works with SVG too!"
+                      )
+                    ).withTooltipOptions(
+                      content = "I'm an SVG tooltip!",
+                      mouseTrack = true
+                    )
                   )
                 )
               }

--- a/prime-react/src/main/scala/lucuma/react/primereact/Tooltip.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/Tooltip.scala
@@ -86,7 +86,7 @@ object Tooltip:
           .applyOrNot(props.autoZIndex, _.autoZIndex(_))
           .applyOrNot(props.baseZIndex, _.baseZIndex(_))
           .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
-          // ST facade erroneusly defines content as String when it should be a ReactNode
+          // ST facade erroneously defines content as String when it should be a ReactNode
           .applyOrNot(props.content, (c, p) => c.content(p.rawNode.asInstanceOf[String]))
           .applyOrNot(props.disabled, _.disabled(_))
           .applyOrNot(props.event, (c, p) => c.event(p.toJs))

--- a/prime-react/src/main/scala/lucuma/react/primereact/Tooltip.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/Tooltip.scala
@@ -1,0 +1,113 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.primereact
+
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.*
+import lucuma.typed.primereact.components.Tooltip as CTooltip
+import lucuma.typed.primereact.primereactStrings.both
+import lucuma.typed.primereact.primereactStrings.bottom
+import lucuma.typed.primereact.primereactStrings.focus
+import lucuma.typed.primereact.primereactStrings.hover
+import lucuma.typed.primereact.primereactStrings.left
+import lucuma.typed.primereact.primereactStrings.right
+import lucuma.typed.primereact.primereactStrings.self
+import lucuma.typed.primereact.primereactStrings.top
+import lucuma.typed.primereact.tooltipTooltipoptionsMod.TooltipEvent
+import org.scalajs.dom.HTMLElement
+
+import scalajs.js
+
+case class Tooltip(
+  appendTo:       js.UndefOr[Tooltip.AppendTo] = js.undefined,
+  at:             js.UndefOr[String] = js.undefined,
+  autoHide:       js.UndefOr[Boolean] = js.undefined,          // default: true
+  autoZIndex:     js.UndefOr[Boolean] = js.undefined,          // default: true
+  baseZIndex:     js.UndefOr[Int] = js.undefined,
+  clazz:          js.UndefOr[Css] = js.undefined,
+  content:        js.UndefOr[VdomNode] = js.undefined,
+  disabled:       js.UndefOr[Boolean] = js.undefined,
+  event:          js.UndefOr[Tooltip.Event] = js.undefined,
+  hideDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
+  hideEvent:      js.UndefOr[String] = js.undefined,           // default: mouseleave
+  id:             js.UndefOr[String] = js.undefined,
+  mouseTrack:     js.UndefOr[Boolean] = js.undefined,          // default: mouseTrack
+  mouseTrackLeft: js.UndefOr[Int] = js.undefined,              // default: 5
+  mouseTrackTop:  js.UndefOr[Int] = js.undefined,              // default: 5
+  my:             js.UndefOr[String] = js.undefined,
+  onBeforeHide:   js.UndefOr[TooltipEvent => Callback] = js.undefined,
+  onBeforeShow:   js.UndefOr[TooltipEvent => Callback] = js.undefined,
+  onHide:         js.UndefOr[TooltipEvent => Callback] = js.undefined,
+  onShow:         js.UndefOr[TooltipEvent => Callback] = js.undefined,
+  position:       js.UndefOr[Tooltip.Position] = js.undefined, // default: right
+  showDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
+  showEvent:      js.UndefOr[String] = js.undefined,           // default: mouseenter
+  showOnDisabled: js.UndefOr[Boolean] = js.undefined,          // default: false
+  // string | string[] | HTMLElement | RefObject<HTMLElement>
+  target:         js.UndefOr[String] = js.undefined,           // query selector
+  targetCss:      js.UndefOr[Css] = js.undefined,              // query selector
+  updateDelay:    js.UndefOr[Int] = js.undefined,              // default: 0
+  modifiers:      Seq[TagMod] = Seq.empty
+) extends ReactFnPropsWithChildren(Tooltip.component) {
+  def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+
+  // You can add content to the tag as children without this method, but if you want
+  // to add event handlers or other attributes, you'll need to use the modifiers.
+  def withMods(mods: TagMod*) = addModifiers(mods)
+}
+
+object Tooltip:
+  enum AppendTo(val toJs: self | HTMLElement):
+    case Self                          extends AppendTo(self)
+    case Element(element: HTMLElement) extends AppendTo(element)
+
+  enum Event(val toJs: hover | focus | both):
+    case Hover extends Event(hover)
+    case Focus extends Event(focus)
+    case Both  extends Event(both)
+
+  enum Position(val toJs: top | bottom | left | right):
+    case Top    extends Position(top)
+    case Bottom extends Position(bottom)
+    case Left   extends Position(left)
+    case Right  extends Position(right)
+
+  private val component =
+    ScalaFnComponent
+      .withHooks[Tooltip]
+      .withPropsChildren
+      .render: (props, children) =>
+        CTooltip
+          .applyOrNot(props.appendTo, (c, p) => c.appendTo(p.toJs))
+          .applyOrNot(props.at, _.at(_))
+          .applyOrNot(props.autoHide, _.autoHide(_))
+          .applyOrNot(props.autoZIndex, _.autoZIndex(_))
+          .applyOrNot(props.baseZIndex, _.baseZIndex(_))
+          .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
+          // ST facade erroneusly defines content as String when it should be a ReactNode
+          .applyOrNot(props.content, (c, p) => c.content(p.rawNode.asInstanceOf[String]))
+          .applyOrNot(props.disabled, _.disabled(_))
+          .applyOrNot(props.event, (c, p) => c.event(p.toJs))
+          .applyOrNot(props.hideDelay, _.hideDelay(_))
+          .applyOrNot(props.hideEvent, _.hideEvent(_))
+          .applyOrNot(props.id, _.id(_))
+          .applyOrNot(props.mouseTrack, _.mouseTrack(_))
+          .applyOrNot(props.mouseTrackLeft, _.mouseTrackLeft(_))
+          .applyOrNot(props.mouseTrackTop, _.mouseTrackTop(_))
+          .applyOrNot(props.my, _.my(_))
+          .applyOrNot(props.onBeforeHide, _.onBeforeHide(_))
+          .applyOrNot(props.onBeforeShow, _.onBeforeShow(_))
+          .applyOrNot(props.onHide, _.onHide(_))
+          .applyOrNot(props.onShow, _.onShow(_))
+          .applyOrNot(props.position, (c, p) => c.position(p.toJs))
+          .applyOrNot(props.showDelay, _.showDelay(_))
+          .applyOrNot(props.showEvent, _.showEvent(_))
+          .applyOrNot(props.showOnDisabled, _.showOnDisabled(_))
+          .applyOrNot(props.target, _.target(_))
+          .applyOrNot(props.targetCss, (c, p) => c.target(p.querySelector))
+          .applyOrNot(props.updateDelay, _.updateDelay(_))(
+            props.modifiers.toTagMod,
+            children
+          )

--- a/prime-react/src/main/scala/lucuma/react/primereact/TooltipOptions.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/TooltipOptions.scala
@@ -4,7 +4,6 @@
 package lucuma.react.primereact
 
 import japgolly.scalajs.react.Callback
-import japgolly.scalajs.react.ReactEventFrom
 import lucuma.typed.primereact.primereactStrings.both
 import lucuma.typed.primereact.primereactStrings.bottom
 import lucuma.typed.primereact.primereactStrings.focus
@@ -13,84 +12,64 @@ import lucuma.typed.primereact.primereactStrings.left
 import lucuma.typed.primereact.primereactStrings.right
 import lucuma.typed.primereact.primereactStrings.self
 import lucuma.typed.primereact.primereactStrings.top
-import org.scalajs.dom.Element
+import lucuma.typed.primereact.tooltipTooltipoptionsMod.TooltipEvent
 import org.scalajs.dom.HTMLElement
 
 import scalajs.js
 
 @js.native
-trait TooltipEventParams extends js.Object:
-  val originalEvent: ReactEventFrom[Element]
-  val target: HTMLElement
-
-@js.native
 trait TooltipOptions extends js.Object:
-  var appendTo: js.UndefOr[self | HTMLElement]                         = js.native
-  var at: js.UndefOr[String]                                           = js.native
-  var autoHide: js.UndefOr[Boolean]                                    = js.native
-  var autoZIndex: js.UndefOr[Boolean]                                  = js.native
-  var baseZIndex: js.UndefOr[Int]                                      = js.native
-  var className: js.UndefOr[String]                                    = js.native
-  var disabled: js.UndefOr[Boolean]                                    = js.native
-  var event: js.UndefOr[hover | focus | both]                          = js.native
-  var hideDelay: js.UndefOr[Int]                                       = js.native
-  var hideEvent: js.UndefOr[String]                                    = js.native
-  var mouseTrack: js.UndefOr[Boolean]                                  = js.native
-  var mouseTrackLeft: js.UndefOr[Int]                                  = js.native
-  var mouseTrackTop: js.UndefOr[Int]                                   = js.native
-  var my: js.UndefOr[String]                                           = js.native
-  var onBeforeHide: js.UndefOr[js.Function1[TooltipEventParams, Unit]] = js.native
-  var onBeforeShow: js.UndefOr[js.Function1[TooltipEventParams, Unit]] = js.native
-  var onHide: js.UndefOr[js.Function1[TooltipEventParams, Unit]]       = js.native
-  var onShow: js.UndefOr[js.Function1[TooltipEventParams, Unit]]       = js.native
-  var position: js.UndefOr[top | bottom | left | right]                = js.native
-  var showDelay: js.UndefOr[Int]                                       = js.native
-  var showEvent: js.UndefOr[String]                                    = js.native
-  var showOnDisabled: js.UndefOr[Boolean]                              = js.native
-  var style: js.UndefOr[js.Object]                                     = js.native
-  var updateDelay: js.UndefOr[Int]                                     = js.native
+  var appendTo: js.UndefOr[self | HTMLElement]                   = js.native
+  var at: js.UndefOr[String]                                     = js.native
+  var autoHide: js.UndefOr[Boolean]                              = js.native
+  var autoZIndex: js.UndefOr[Boolean]                            = js.native
+  var baseZIndex: js.UndefOr[Int]                                = js.native
+  var className: js.UndefOr[String]                              = js.native
+  var disabled: js.UndefOr[Boolean]                              = js.native
+  var event: js.UndefOr[hover | focus | both]                    = js.native
+  var hideDelay: js.UndefOr[Int]                                 = js.native
+  var hideEvent: js.UndefOr[String]                              = js.native
+  var mouseTrack: js.UndefOr[Boolean]                            = js.native
+  var mouseTrackLeft: js.UndefOr[Int]                            = js.native
+  var mouseTrackTop: js.UndefOr[Int]                             = js.native
+  var my: js.UndefOr[String]                                     = js.native
+  var onBeforeHide: js.UndefOr[js.Function1[TooltipEvent, Unit]] = js.native
+  var onBeforeShow: js.UndefOr[js.Function1[TooltipEvent, Unit]] = js.native
+  var onHide: js.UndefOr[js.Function1[TooltipEvent, Unit]]       = js.native
+  var onShow: js.UndefOr[js.Function1[TooltipEvent, Unit]]       = js.native
+  var position: js.UndefOr[top | bottom | left | right]          = js.native
+  var showDelay: js.UndefOr[Int]                                 = js.native
+  var showEvent: js.UndefOr[String]                              = js.native
+  var showOnDisabled: js.UndefOr[Boolean]                        = js.native
+  var style: js.UndefOr[js.Object]                               = js.native
+  var updateDelay: js.UndefOr[Int]                               = js.native
 
 object TooltipOptions:
-  enum AppendTo(val toJs: self | HTMLElement):
-    case Self                          extends AppendTo(self)
-    case Element(element: HTMLElement) extends AppendTo(element)
-
-  enum Event(val toJs: hover | focus | both):
-    case Hover extends Event(hover)
-    case Focus extends Event(focus)
-    case Both  extends Event(both)
-
-  enum Position(val toJs: top | bottom | left | right):
-    case Top    extends Position(top)
-    case Bottom extends Position(bottom)
-    case Left   extends Position(left)
-    case Right  extends Position(right)
-
   def apply(
-    appendTo:       js.UndefOr[TooltipOptions.AppendTo] = js.undefined,
+    appendTo:       js.UndefOr[Tooltip.AppendTo] = js.undefined,
     at:             js.UndefOr[String] = js.undefined,
-    autoHide:       js.UndefOr[Boolean] = js.undefined,                 // default: true
-    autoZIndex:     js.UndefOr[Boolean] = js.undefined,                 // default: true
+    autoHide:       js.UndefOr[Boolean] = js.undefined,          // default: true
+    autoZIndex:     js.UndefOr[Boolean] = js.undefined,          // default: true
     baseZIndex:     js.UndefOr[Int] = js.undefined,
     className:      js.UndefOr[String] = js.undefined,
     disabled:       js.UndefOr[Boolean] = js.undefined,
-    event:          js.UndefOr[TooltipOptions.Event] = js.undefined,
-    hideDelay:      js.UndefOr[Int] = js.undefined,                     // default: 0
-    hideEvent:      js.UndefOr[String] = js.undefined,                  // default: mouseleave
-    mouseTrack:     js.UndefOr[Boolean] = js.undefined,                 // default: mouseTrack
-    mouseTrackLeft: js.UndefOr[Int] = js.undefined,                     // default: 5
-    mouseTrackTop:  js.UndefOr[Int] = js.undefined,                     // default: 5
+    event:          js.UndefOr[Tooltip.Event] = js.undefined,
+    hideDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
+    hideEvent:      js.UndefOr[String] = js.undefined,           // default: mouseleave
+    mouseTrack:     js.UndefOr[Boolean] = js.undefined,          // default: mouseTrack
+    mouseTrackLeft: js.UndefOr[Int] = js.undefined,              // default: 5
+    mouseTrackTop:  js.UndefOr[Int] = js.undefined,              // default: 5
     my:             js.UndefOr[String] = js.undefined,
-    onBeforeHide:   js.UndefOr[TooltipEventParams => Callback] = js.undefined,
-    onBeforeShow:   js.UndefOr[TooltipEventParams => Callback] = js.undefined,
-    onHide:         js.UndefOr[TooltipEventParams => Callback] = js.undefined,
-    onShow:         js.UndefOr[TooltipEventParams => Callback] = js.undefined,
-    position:       js.UndefOr[TooltipOptions.Position] = js.undefined, // default: right
-    showDelay:      js.UndefOr[Int] = js.undefined,                     // default: 0
-    showEvent:      js.UndefOr[String] = js.undefined,                  // default: mouseenter
-    showOnDisabled: js.UndefOr[Boolean] = js.undefined,                 // default: false
+    onBeforeHide:   js.UndefOr[TooltipEvent => Callback] = js.undefined,
+    onBeforeShow:   js.UndefOr[TooltipEvent => Callback] = js.undefined,
+    onHide:         js.UndefOr[TooltipEvent => Callback] = js.undefined,
+    onShow:         js.UndefOr[TooltipEvent => Callback] = js.undefined,
+    position:       js.UndefOr[Tooltip.Position] = js.undefined, // default: right
+    showDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
+    showEvent:      js.UndefOr[String] = js.undefined,           // default: mouseenter
+    showOnDisabled: js.UndefOr[Boolean] = js.undefined,          // default: false
     style:          js.UndefOr[js.Object] = js.undefined,
-    updateDelay:    js.UndefOr[Int] = js.undefined                      // default: 0
+    updateDelay:    js.UndefOr[Int] = js.undefined               // default: 0
   ): TooltipOptions = {
     val p = (new js.Object).asInstanceOf[TooltipOptions]
     appendTo.foreach(v => p.appendTo = v.toJs)

--- a/prime-react/src/main/scala/lucuma/react/primereact/tooltip/package.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/tooltip/package.scala
@@ -4,10 +4,10 @@
 package lucuma.react.primereact.tooltip
 
 import japgolly.scalajs.react.vdom.TagOf
+import japgolly.scalajs.react.vdom.TopNode
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.Css
 import lucuma.react.primereact.Tooltip
-import org.scalajs.dom.HTMLElement
 
 import scalajs.js
 
@@ -71,7 +71,7 @@ val tooltipAutoHide = VdomAttr("data-pr-autohide")
 /** Whether to show tooltip for disabled elements. Default: false */
 val tooltipShowOnDisabled = VdomAttr("data-pr-showondisabled")
 
-extension (self: TagOf[HTMLElement])
+extension [E <: TopNode](self: TagOf[E])
   def withTooltipOptions(
     content:        js.UndefOr[String] = js.undefined,
     disabled:       js.UndefOr[Boolean] = js.undefined,
@@ -90,7 +90,7 @@ extension (self: TagOf[HTMLElement])
     hideDelay:      js.UndefOr[Int] = js.undefined,
     autoHide:       js.UndefOr[Boolean] = js.undefined,
     showOnDisabled: js.UndefOr[Boolean] = js.undefined
-  ): TagOf[HTMLElement] =
+  ): TagOf[E] =
     self(
       content.map(tooltipContent := _).whenDefined,
       disabled.map(tooltipDisabled := _).whenDefined,

--- a/prime-react/src/main/scala/lucuma/react/primereact/tooltip/package.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/tooltip/package.scala
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.primereact.tooltip
+
+import japgolly.scalajs.react.vdom.TagOf
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.Css
+import lucuma.react.primereact.Tooltip
+import org.scalajs.dom.HTMLElement
+
+import scalajs.js
+
+/** Content to be displayed in tooltip. Default: null */
+val tooltipContent = VdomAttr("data-pr-tooltip")
+
+/** When present, it specifies that the tooltip should be hidden. Default: false */
+val tooltipDisabled = VdomAttr("data-pr-disabled")
+
+/** Style class of the tooltip. Default: null */
+val tooltipClassName = VdomAttr("data-pr-classname")
+
+/** Position of the tooltip. Default: right */
+val tooltipPosition = VdomAttr("data-pr-position")
+
+/**
+ * Defines which position on the tooltip being positioned to align with the target element. Default:
+ * null
+ */
+val tooltipMy = VdomAttr("data-pr-my")
+
+/** Defines which position on the target element to align the positioned tooltip. Default: null */
+val tooltipAt = VdomAttr("data-pr-at")
+
+/** Event to trigger the tooltip. Default: hover */
+val tooltipEvent = VdomAttr("data-pr-event")
+
+/** Event to show the tooltip if the event property is empty. Default: mouseenter */
+val tooltipShowEvent = VdomAttr("data-pr-showevent")
+
+/** Event to hide the tooltip if the event property is empty. Default: mouseleave */
+val tooltipHideEvent = VdomAttr("data-pr-hideevent")
+
+/** Whether the tooltip will follow the mouse. Default: false */
+val tooltipMouseTrack = VdomAttr("data-pr-mousetrack")
+
+/**
+ * Defines top position of the tooltip in relation to the mouse when the mouseTrack is enabled.
+ * Default: 5
+ */
+val tooltipMouseTrackTop = VdomAttr("data-pr-mousetracktop")
+
+/**
+ * Defines left position of the tooltip in relation to the mouse when the mouseTrack is enabled.
+ * Default: 5
+ */
+val tooltipMouseTrackLeft = VdomAttr("data-pr-mousetrackleft")
+
+/** Delay to show the tooltip in milliseconds. Default: 0 */
+val tooltipShowDelay = VdomAttr("data-pr-showdelay")
+
+/** Delay to update the tooltip in milliseconds. Default: 0 */
+val tooltipUpdateDelay = VdomAttr("data-pr-updatedelay")
+
+/** Delay to hide the tooltip in milliseconds. Default: 0 */
+val tooltipHideDelay = VdomAttr("data-pr-hidedelay")
+
+/** Whether to hide tooltip when hovering over tooltip content. Default: true */
+val tooltipAutoHide = VdomAttr("data-pr-autohide")
+
+/** Whether to show tooltip for disabled elements. Default: false */
+val tooltipShowOnDisabled = VdomAttr("data-pr-showondisabled")
+
+extension (self: TagOf[HTMLElement])
+  def withTooltipOptions(
+    content:        js.UndefOr[String] = js.undefined,
+    disabled:       js.UndefOr[Boolean] = js.undefined,
+    clazz:          js.UndefOr[Css] = js.undefined,
+    position:       js.UndefOr[Tooltip.Position] = js.undefined,
+    my:             js.UndefOr[String] = js.undefined,
+    at:             js.UndefOr[String] = js.undefined,
+    event:          js.UndefOr[Tooltip.Event] = js.undefined,
+    showEvent:      js.UndefOr[String] = js.undefined,
+    hideEvent:      js.UndefOr[String] = js.undefined,
+    mouseTrack:     js.UndefOr[Boolean] = js.undefined,
+    mouseTrackTop:  js.UndefOr[Int] = js.undefined,
+    mouseTrackLeft: js.UndefOr[Int] = js.undefined,
+    showDelay:      js.UndefOr[Int] = js.undefined,
+    updateDelay:    js.UndefOr[Int] = js.undefined,
+    hideDelay:      js.UndefOr[Int] = js.undefined,
+    autoHide:       js.UndefOr[Boolean] = js.undefined,
+    showOnDisabled: js.UndefOr[Boolean] = js.undefined
+  ): TagOf[HTMLElement] =
+    self(
+      content.map(tooltipContent := _).whenDefined,
+      disabled.map(tooltipDisabled := _).whenDefined,
+      clazz.map(tooltipClassName := _.htmlClass).whenDefined,
+      position.map(tooltipPosition := _.toJs).whenDefined,
+      my.map(tooltipMy := _).whenDefined,
+      at.map(tooltipAt := _).whenDefined,
+      event.map(tooltipEvent := _.toJs).whenDefined,
+      showEvent.map(tooltipShowEvent := _).whenDefined,
+      hideEvent.map(tooltipHideEvent := _).whenDefined,
+      mouseTrack.map(tooltipMouseTrack := _).whenDefined,
+      mouseTrackTop.map(tooltipMouseTrackTop := _).whenDefined,
+      mouseTrackLeft.map(tooltipMouseTrackLeft := _).whenDefined,
+      showDelay.map(tooltipShowDelay := _).whenDefined,
+      updateDelay.map(tooltipUpdateDelay := _).whenDefined,
+      hideDelay.map(tooltipHideDelay := _).whenDefined,
+      autoHide.map(tooltipAutoHide := _).whenDefined,
+      showOnDisabled.map(tooltipShowOnDisabled := _).whenDefined
+    )


### PR DESCRIPTION
Implement `Tooltip` component from PrimeReact, which allows attaching tooltips to HTML tags.

Usage, as shown on demo:
``` scala
val tooltipTarget = Css("tooltip-target")

React.Fragment(
  Tooltip(targetCss = tooltipTarget, content = "I am a tooltip"),
  <.span(tooltipTarget, "I am a <span>. Hover over me to see a tooltip."),
  <.span(
    tooltipTarget, "I am another <span>. Hover over me to see a tooltip too."
  ).withTooltipOptions(
    content = "I'm another tooltip!",
    position = Tooltip.Position.Bottom
  )
)
```