### PR TITLE
Better tooltip API and shorthands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.59"
+ThisBuild / tlBaseVersion       := "0.60"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
+++ b/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
@@ -429,10 +429,8 @@ object DemoControlsPanel {
                 val TooltipTarget = Css("tooltip-target")
 
                 React.Fragment(
-                  Tooltip(
-                    targetCss = TooltipTarget,
-                    content = "I am a tooltip",
-                    position = Tooltip.Position.Top
+                  Tooltip(targetCss = TooltipTarget, position = Tooltip.Position.Top)(
+                    <.h1("I am a big tooltip")
                   ),
                   <.span(TooltipTarget)("I am a <span>. Hover over me to see a tooltip."),
                   <.br,
@@ -463,6 +461,17 @@ object DemoControlsPanel {
                       content = "I'm an SVG tooltip!",
                       mouseTrack = true
                     )
+                  ),
+                  <.br,
+                  Tooltip.Fragment(
+                    position = Tooltip.Position.Top,
+                    content = <.h4(^.color.yellow)("I'm a tooltip in Tooltip.Fragment")
+                  )(<.span("I'm a span with my own, non-shared, tooltip")),
+                  <.br,
+                  <.br,
+                  <.span("I'm another span with my own, non-shared, tooltip").withTooltip(
+                    position = Tooltip.Position.Bottom,
+                    content = <.h4(^.color.teal)("I'm a tooltip rendered with .withTooltip")
                   )
                 )
               }

--- a/prime-react/src/main/scala/lucuma/react/primereact/Tooltip.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/Tooltip.scala
@@ -3,7 +3,10 @@
 
 package lucuma.react.primereact
 
+import cats.syntax.option.*
 import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.TagOf
+import japgolly.scalajs.react.vdom.TopNode
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.*
 import lucuma.typed.primereact.components.Tooltip as CTooltip
@@ -18,8 +21,14 @@ import lucuma.typed.primereact.primereactStrings.top
 import lucuma.typed.primereact.tooltipTooltipoptionsMod.TooltipEvent
 import org.scalajs.dom.HTMLElement
 
+import scala.scalajs.js.JSConverters.*
+
 import scalajs.js
 
+// `Tooltip` component with `target` is useful for sharing the tooltip among multiple elements.
+//   Especially useful for tables.
+// `Tooltip.Fragment` provides a convenient shorthand for when you want to use a tooltip with a single element.
+//   It can be used with the syntax: <HTMLElement>.withTooltip(<options>...)
 case class Tooltip(
   appendTo:       js.UndefOr[Tooltip.AppendTo] = js.undefined,
   at:             js.UndefOr[String] = js.undefined,
@@ -27,7 +36,7 @@ case class Tooltip(
   autoZIndex:     js.UndefOr[Boolean] = js.undefined,          // default: true
   baseZIndex:     js.UndefOr[Int] = js.undefined,
   clazz:          js.UndefOr[Css] = js.undefined,
-  content:        js.UndefOr[VdomNode] = js.undefined,
+  content:        js.UndefOr[String] = js.undefined,
   disabled:       js.UndefOr[Boolean] = js.undefined,
   event:          js.UndefOr[Tooltip.Event] = js.undefined,
   hideDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
@@ -37,17 +46,16 @@ case class Tooltip(
   mouseTrackLeft: js.UndefOr[Int] = js.undefined,              // default: 5
   mouseTrackTop:  js.UndefOr[Int] = js.undefined,              // default: 5
   my:             js.UndefOr[String] = js.undefined,
-  onBeforeHide:   js.UndefOr[TooltipEvent => Callback] = js.undefined,
-  onBeforeShow:   js.UndefOr[TooltipEvent => Callback] = js.undefined,
-  onHide:         js.UndefOr[TooltipEvent => Callback] = js.undefined,
-  onShow:         js.UndefOr[TooltipEvent => Callback] = js.undefined,
+  onBeforeHide:   js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+  onBeforeShow:   js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+  onHide:         js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+  onShow:         js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
   position:       js.UndefOr[Tooltip.Position] = js.undefined, // default: right
   showDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
   showEvent:      js.UndefOr[String] = js.undefined,           // default: mouseenter
   showOnDisabled: js.UndefOr[Boolean] = js.undefined,          // default: false
-  // string | string[] | HTMLElement | RefObject<HTMLElement>
-  target:         js.UndefOr[String] = js.undefined,           // query selector
-  targetCss:      js.UndefOr[Css] = js.undefined,              // query selector
+  target:         js.UndefOr[Tooltip.Target] = js.undefined,
+  targetCss:      js.UndefOr[Css] = js.undefined,
   updateDelay:    js.UndefOr[Int] = js.undefined,              // default: 0
   modifiers:      Seq[TagMod] = Seq.empty
 ) extends ReactFnPropsWithChildren(Tooltip.component) {
@@ -74,6 +82,18 @@ object Tooltip:
     case Left   extends Position(left)
     case Right  extends Position(right)
 
+  type EventRaw = TooltipEvent
+
+  // Strings are query selectors
+  type Target = String | List[String] | HTMLElement
+
+  private type TargetRaw = String | js.Array[String] | HTMLElement
+  extension (t: Target)
+    private def toJs: TargetRaw = t match
+      case s: String       => s
+      case l: List[String] => l.toJSArray
+      case e: HTMLElement  => e
+
   private val component =
     ScalaFnComponent
       .withHooks[Tooltip]
@@ -86,8 +106,7 @@ object Tooltip:
           .applyOrNot(props.autoZIndex, _.autoZIndex(_))
           .applyOrNot(props.baseZIndex, _.baseZIndex(_))
           .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))
-          // ST facade erroneously defines content as String when it should be a ReactNode
-          .applyOrNot(props.content, (c, p) => c.content(p.rawNode.asInstanceOf[String]))
+          .applyOrNot(props.content, _.content(_))
           .applyOrNot(props.disabled, _.disabled(_))
           .applyOrNot(props.event, (c, p) => c.event(p.toJs))
           .applyOrNot(props.hideDelay, _.hideDelay(_))
@@ -105,9 +124,80 @@ object Tooltip:
           .applyOrNot(props.showDelay, _.showDelay(_))
           .applyOrNot(props.showEvent, _.showEvent(_))
           .applyOrNot(props.showOnDisabled, _.showOnDisabled(_))
-          .applyOrNot(props.target, _.target(_))
+          .applyOrNot(props.target, (c, p) => c.target(p.toJs))
           .applyOrNot(props.targetCss, (c, p) => c.target(p.querySelector))
           .applyOrNot(props.updateDelay, _.updateDelay(_))(
             props.modifiers.toTagMod,
             children
+          )
+
+  case class Fragment(
+    appendTo:       js.UndefOr[Tooltip.AppendTo] = js.undefined,
+    at:             js.UndefOr[String] = js.undefined,
+    autoHide:       js.UndefOr[Boolean] = js.undefined,          // default: true
+    autoZIndex:     js.UndefOr[Boolean] = js.undefined,          // default: true
+    baseZIndex:     js.UndefOr[Int] = js.undefined,
+    clazz:          js.UndefOr[Css] = js.undefined,
+    content:        js.UndefOr[VdomNode] = js.undefined,
+    disabled:       js.UndefOr[Boolean] = js.undefined,
+    event:          js.UndefOr[Tooltip.Event] = js.undefined,
+    hideDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
+    hideEvent:      js.UndefOr[String] = js.undefined,           // default: mouseleave
+    id:             js.UndefOr[String] = js.undefined,
+    mouseTrack:     js.UndefOr[Boolean] = js.undefined,          // default: mouseTrack
+    mouseTrackLeft: js.UndefOr[Int] = js.undefined,              // default: 5
+    mouseTrackTop:  js.UndefOr[Int] = js.undefined,              // default: 5
+    my:             js.UndefOr[String] = js.undefined,
+    onBeforeHide:   js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+    onBeforeShow:   js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+    onHide:         js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+    onShow:         js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+    position:       js.UndefOr[Tooltip.Position] = js.undefined, // default: right
+    showDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
+    showEvent:      js.UndefOr[String] = js.undefined,           // default: mouseenter
+    showOnDisabled: js.UndefOr[Boolean] = js.undefined,          // default: false
+    updateDelay:    js.UndefOr[Int] = js.undefined               // default: 0
+  )(val tag: TagOf[HTMLElement])
+      extends ReactFnPropsWithChildren(Fragment.component)
+
+  object Fragment:
+    private val component =
+      ScalaFnComponent
+        .withHooks[Fragment]
+        .withPropsChildren
+        // We use state instead of a regular Ref in order to force a rerender when it's set.
+        .useState(none[HTMLElement])
+        .render: (props, children, ref) =>
+          React.Fragment(
+            Tooltip(
+              appendTo = props.appendTo,
+              at = props.at,
+              autoHide = props.autoHide,
+              autoZIndex = props.autoZIndex,
+              baseZIndex = props.baseZIndex,
+              clazz = props.clazz,
+              disabled = props.disabled,
+              event = props.event,
+              hideDelay = props.hideDelay,
+              hideEvent = props.hideEvent,
+              mouseTrack = props.mouseTrack,
+              mouseTrackLeft = props.mouseTrackLeft,
+              mouseTrackTop = props.mouseTrackTop,
+              my = props.my,
+              onBeforeHide = props.onBeforeHide,
+              onBeforeShow = props.onBeforeShow,
+              onHide = props.onHide,
+              onShow = props.onShow,
+              position = props.position,
+              showDelay = props.showDelay,
+              showEvent = props.showEvent,
+              showOnDisabled = props.showOnDisabled,
+              target = ref.value.orUndefined,
+              updateDelay = props.updateDelay
+            )(props.content),
+            props.tag(^.untypedRef { (node: TopNode | Null) =>
+              ref
+                .modState(_.fold(Option(node.asInstanceOf[HTMLElement]))(_.some))
+                .runNow()
+            }.when(ref.value.isEmpty))
           )

--- a/prime-react/src/main/scala/lucuma/react/primereact/tooltip/package.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/tooltip/package.scala
@@ -3,11 +3,13 @@
 
 package lucuma.react.primereact.tooltip
 
+import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.vdom.TagOf
 import japgolly.scalajs.react.vdom.TopNode
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.Css
 import lucuma.react.primereact.Tooltip
+import org.scalajs.dom.HTMLElement
 
 import scalajs.js
 
@@ -110,3 +112,58 @@ extension [E <: TopNode](self: TagOf[E])
       autoHide.map(tooltipAutoHide := _).whenDefined,
       showOnDisabled.map(tooltipShowOnDisabled := _).whenDefined
     )
+
+extension (self: TagOf[HTMLElement])
+  def withTooltip(
+    appendTo:       js.UndefOr[Tooltip.AppendTo] = js.undefined,
+    at:             js.UndefOr[String] = js.undefined,
+    autoHide:       js.UndefOr[Boolean] = js.undefined,          // default: true
+    autoZIndex:     js.UndefOr[Boolean] = js.undefined,          // default: true
+    baseZIndex:     js.UndefOr[Int] = js.undefined,
+    clazz:          js.UndefOr[Css] = js.undefined,
+    content:        js.UndefOr[VdomNode] = js.undefined,
+    disabled:       js.UndefOr[Boolean] = js.undefined,
+    event:          js.UndefOr[Tooltip.Event] = js.undefined,
+    hideDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
+    hideEvent:      js.UndefOr[String] = js.undefined,           // default: mouseleave
+    id:             js.UndefOr[String] = js.undefined,
+    mouseTrack:     js.UndefOr[Boolean] = js.undefined,          // default: mouseTrack
+    mouseTrackLeft: js.UndefOr[Int] = js.undefined,              // default: 5
+    mouseTrackTop:  js.UndefOr[Int] = js.undefined,              // default: 5
+    my:             js.UndefOr[String] = js.undefined,
+    onBeforeHide:   js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+    onBeforeShow:   js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+    onHide:         js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+    onShow:         js.UndefOr[Tooltip.EventRaw => Callback] = js.undefined,
+    position:       js.UndefOr[Tooltip.Position] = js.undefined, // default: right
+    showDelay:      js.UndefOr[Int] = js.undefined,              // default: 0
+    showEvent:      js.UndefOr[String] = js.undefined,           // default: mouseenter
+    showOnDisabled: js.UndefOr[Boolean] = js.undefined,          // default: false
+    updateDelay:    js.UndefOr[Int] = js.undefined               // default: 0
+  ): VdomElement = Tooltip.Fragment(
+    appendTo = appendTo,
+    at = at,
+    autoHide = autoHide,
+    autoZIndex = autoZIndex,
+    baseZIndex = baseZIndex,
+    clazz = clazz,
+    content = content,
+    disabled = disabled,
+    event = event,
+    hideDelay = hideDelay,
+    hideEvent = hideEvent,
+    id = id,
+    mouseTrack = mouseTrack,
+    mouseTrackLeft = mouseTrackLeft,
+    mouseTrackTop = mouseTrackTop,
+    my = my,
+    onBeforeHide = onBeforeHide,
+    onBeforeShow = onBeforeShow,
+    onHide = onHide,
+    onShow = onShow,
+    position = position,
+    showDelay = showDelay,
+    showEvent = showEvent,
+    showOnDisabled = showOnDisabled,
+    updateDelay = updateDelay
+  )(self)


### PR DESCRIPTION
Turns out that the `content` property had to be a `String`.

This PR fixes that and adds a `Tooltip.Fragment` alternative that renders a `Tooltip` and a passed `HTMLElement` as a `React.Fragment`. This can also be invoked as `<HTMLElement>.withTooltip(<options>...)`.