### PR TITLE
react-table full Scala facade, with meta

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.62"
+ThisBuild / tlBaseVersion       := "0.63"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/tanstack-table-demo/src/main/scala/lucuma/react/table/demo/Table3.scala
+++ b/tanstack-table-demo/src/main/scala/lucuma/react/table/demo/Table3.scala
@@ -23,13 +23,13 @@ object Table3:
             ColumnId("expander"),
             header = header =>
               <.span(^.cursor.pointer)(
-                ^.onClick ==> (e => Callback(header.table.getToggleAllRowsExpandedHandler()(e))),
+                ^.onClick ==> header.table.getToggleAllRowsExpandedHandler(),
                 if (header.table.getIsAllRowsExpanded()) "👇" else "👉"
               ),
             cell = cell =>
               if (cell.row.getCanExpand())
                 <.span(^.cursor.pointer)(
-                  ^.onClick --> Callback(cell.row.getToggleExpandedHandler()()),
+                  ^.onClick --> cell.row.getToggleExpandedHandler(),
                   if (cell.row.getIsExpanded()) "👇" else "👉"
                 )
               else "",

--- a/tanstack-table/src/main/scala/lucuma/react/table/Cell.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/Cell.scala
@@ -5,12 +5,12 @@ package lucuma.react.table
 
 import lucuma.typed.tanstackTableCore as raw
 
-case class Cell[T, A](private val toJs: raw.buildLibTypesMod.Cell[T, A]):
-  lazy val id: CellId                                         = CellId(toJs.id)
-  lazy val row: Row[T]                                        = Row(toJs.row)
-  lazy val column: Column[T, A]                               = Column(toJs.column)
-  def getContext(): raw.buildLibCoreCellMod.CellContext[T, A] = toJs.getContext()
-  def getValue[V](): V                                        = toJs.getValue().asInstanceOf[V]
+case class Cell[T, A, TM, CM](private val toJs: raw.buildLibTypesMod.Cell[T, A]):
+  lazy val id: CellId                         = CellId(toJs.id)
+  lazy val row: Row[T, TM]                    = Row(toJs.row)
+  lazy val column: Column[T, A, TM, CM]       = Column(toJs.column)
+  def getContext(): CellContext[T, A, TM, CM] = CellContext(toJs.getContext())
+  def getValue[V](): V                        = toJs.getValue().asInstanceOf[V]
 
   // Grouping
   def getIsAggregated(): Boolean  = toJs.getIsAggregated()

--- a/tanstack-table/src/main/scala/lucuma/react/table/CellContext.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/CellContext.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.table
+
+import lucuma.typed.tanstackTableCore as raw
+
+case class CellContext[T, A, TM, CM] private[table] (
+  private[table] val toJs: raw.buildLibCoreCellMod.CellContext[T, A]
+):
+  lazy val cell: Cell[T, A, TM, CM] = Cell(toJs.cell)
+
+  lazy val column: Column[T, A, TM, CM] = Column(toJs.column)
+
+  def getValue(): A = toJs.getValue().asInstanceOf[A]
+
+  lazy val value: A = getValue() // Added for convenience
+
+  def renderValue(): Option[A] = Option(toJs.renderValue().asInstanceOf[A])
+
+  lazy val row: Row[T, TM] = Row(toJs.row)
+
+  lazy val table: Table[T, TM] = Table(toJs.table)

--- a/tanstack-table/src/main/scala/lucuma/react/table/CellContext.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/CellContext.scala
@@ -8,16 +8,10 @@ import lucuma.typed.tanstackTableCore as raw
 case class CellContext[T, A, TM, CM] private[table] (
   private[table] val toJs: raw.buildLibCoreCellMod.CellContext[T, A]
 ):
-  lazy val cell: Cell[T, A, TM, CM] = Cell(toJs.cell)
-
+  lazy val cell: Cell[T, A, TM, CM]     = Cell(toJs.cell)
   lazy val column: Column[T, A, TM, CM] = Column(toJs.column)
-
-  def getValue(): A = toJs.getValue().asInstanceOf[A]
-
-  lazy val value: A = getValue() // Added for convenience
-
-  def renderValue(): Option[A] = Option(toJs.renderValue().asInstanceOf[A])
-
-  lazy val row: Row[T, TM] = Row(toJs.row)
-
-  lazy val table: Table[T, TM] = Table(toJs.table)
+  def getValue(): A                     = toJs.getValue().asInstanceOf[A]
+  lazy val value: A                     = getValue() // Added for convenience
+  def renderValue(): Option[A]          = Option(toJs.renderValue().asInstanceOf[A])
+  lazy val row: Row[T, TM]              = Row(toJs.row)
+  lazy val table: Table[T, TM]          = Table(toJs.table)

--- a/tanstack-table/src/main/scala/lucuma/react/table/Column.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/Column.scala
@@ -13,23 +13,25 @@ import org.scalajs.dom
 import scalajs.js.JSConverters.*
 
 // Missing: ColumnPinning, Filters, Grouping
-case class Column[T, A](private val toJs: raw.buildLibTypesMod.Column[T, A]):
-  lazy val id: ColumnId                      = ColumnId(toJs.id)
-  lazy val depth: Int                        = toJs.depth.toInt
-  lazy val accessorFn: Option[(T, Int) => A] =
+case class Column[T, A, TM, CM] private[table] (
+  private val toJs: raw.buildLibTypesMod.Column[T, A]
+):
+  lazy val id: ColumnId                               = ColumnId(toJs.id)
+  lazy val depth: Int                                 = toJs.depth.toInt
+  lazy val accessorFn: Option[(T, Int) => A]          =
     toJs.accessorFn.toOption.map(f => (row, index) => f(row, index))
-  lazy val columnDef: ColumnDef[T, A]        =
-    ColumnDef.fromJs(toJs.columnDef.asInstanceOf[ColumnDefJs[T, A]])
-  lazy val columns: List[Column[T, Any]]     =
+  lazy val columnDef: ColumnDef[T, A, TM, CM]         =
+    ColumnDef.fromJs(toJs.columnDef.asInstanceOf[ColumnDefJs[T, A, TM, CM]])
+  lazy val columns: List[Column[T, Any, TM, Any]]     =
     toJs.columns.toList.map(col => Column(col.asInstanceOf[raw.buildLibTypesMod.Column[T, Any]]))
-  lazy val parent: Option[Column[T, Any]]    =
+  lazy val parent: Option[Column[T, Any, TM, Any]]    =
     toJs.parent.toOption.map(col => Column(col.asInstanceOf[raw.buildLibTypesMod.Column[T, Any]]))
-  def getFlatColumns(): List[Column[T, Any]] =
+  def getFlatColumns(): List[Column[T, Any, TM, CM]]  =
     toJs
       .getFlatColumns()
       .toList
       .map(col => Column(col.asInstanceOf[raw.buildLibTypesMod.Column[T, Any]]))
-  def getLeafColumns(): List[Column[T, Any]] =
+  def getLeafColumns(): List[Column[T, Any, TM, Any]] =
     toJs
       .getLeafColumns()
       .toList
@@ -47,7 +49,7 @@ case class Column[T, A](private val toJs: raw.buildLibTypesMod.Column[T, A]):
   def clearSorting(): Callback                                                = Callback(toJs.clearSorting())
   def getAutoSortDir(): SortDirection                                         =
     SortDirection.fromDescending(toJs.getAutoSortDir() == raw.tanstackTableCoreStrings.desc)
-  def getAutoSortingFn(): SortingFn[T]                                        =
+  def getAutoSortingFn(): SortingFn[T, TM]                                    =
     (rowA, rowB, colId) => toJs.getAutoSortingFn()(rowA.toJs, rowB.toJs, colId.value).toInt
   def getCanMultiSort(): Boolean                                              = toJs.getCanMultiSort()
   def getCanSort(): Boolean                                                   = toJs.getCanSort()
@@ -63,7 +65,7 @@ case class Column[T, A](private val toJs: raw.buildLibTypesMod.Column[T, A]):
       .filterNot(_ == raw.tanstackTableCoreBooleans.`false`)
       .map(dir => SortDirection.fromDescending(dir == raw.tanstackTableCoreStrings.desc))
   def getSortIndex(): Int                                                     = toJs.getSortIndex().toInt
-  def getSortingFn(): SortingFn[T]                                            =
+  def getSortingFn(): SortingFn[T, TM]                                        =
     (rowA, rowB, colId) => toJs.getSortingFn()(rowA.toJs, rowB.toJs, colId.value).toInt
   def getToggleSortingHandler(): Option[SyntheticEvent[dom.Node] => Callback] =
     toJs.getToggleSortingHandler().toOption.map(fn => e => Callback(fn(e)))

--- a/tanstack-table/src/main/scala/lucuma/react/table/ColumnDef.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/ColumnDef.scala
@@ -13,11 +13,11 @@ import lucuma.typed.tanstackTableCore as raw
 import scalajs.js
 import scalajs.js.JSConverters.*
 
-sealed trait ColumnDef[T, A]:
+sealed trait ColumnDef[T, A, TM, CM]:
   def id: ColumnId
-  def header: js.UndefOr[String | (raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode)]
-  def footer: js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode]
-  def meta: js.UndefOr[Any]
+  def header: js.UndefOr[String | (HeaderContext[T, A, TM, CM] => VdomNode)]
+  def footer: js.UndefOr[HeaderContext[T, A, TM, CM] => VdomNode]
+  def meta: js.UndefOr[CM]
 
   // Column Sizing
   def enableResizing: js.UndefOr[Boolean]
@@ -28,167 +28,190 @@ sealed trait ColumnDef[T, A]:
   // Column Visibility
   def enableHiding: js.UndefOr[Boolean]
 
-  private[table] def toJs: ColumnDefJs[T, A]
+  private[table] def toJs: ColumnDefJs[T, A, TM, CM]
 
 object ColumnDef:
-  // Should we have a Display case??
+  type NoMeta[T, A]             = ColumnDef[T, A, Nothing, Nothing]
+  type WithTableMeta[T, A, TM]  = ColumnDef[T, A, TM, Nothing]
+  type WithColumnMeta[T, A, CM] = ColumnDef[T, A, Nothing, CM]
 
-  case class Single[T, A](private[table] val toJs: ColumnDefJs[T, A]) extends ColumnDef[T, A]:
+  case class Single[T, A, TM, CM](private[table] val toJs: ColumnDefJs[T, A, TM, CM])
+      extends ColumnDef[T, A, TM, CM]:
     lazy val id: ColumnId = ColumnId(toJs.id)
 
     /** WARNING: This mutates the object in-place. */
-    def setId(id: ColumnId): Single[T, A] = Single { toJs.id = id.value; toJs }
+    def setId(id: ColumnId): Single[T, A, TM, CM] = Single { toJs.id = id.value; toJs }
 
     lazy val accessor: js.UndefOr[T => A] =
       toJs.accessorFn.map(identity) // This makes implicit conversions kick-in
 
     /** WARNING: This mutates the object in-place. */
-    def setAccessor(accessor: js.UndefOr[T => A]): Single[T, A] = Single {
+    def setAccessor(accessor: js.UndefOr[T => A]): Single[T, A, TM, CM] = Single {
       toJs.accessorFn = accessor.map(identity); toJs
     }
 
-    lazy val header
-      : js.UndefOr[String | (raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode)] =
-      toJs.header.map(v =>
+    lazy val header: js.UndefOr[String | (HeaderContext[T, A, TM, CM] => VdomNode)] =
+      toJs.header.map: v =>
         js.typeOf(v) match
           case "string" => v.asInstanceOf[String]
-          case fn       =>
-            fn.asInstanceOf[js.Function1[raw.buildLibCoreHeadersMod.HeaderContext[T, A], Node]]
-              .andThen(VdomNode(_))
-      )
+          case renderFn =>
+            (headerContext: HeaderContext[T, A, TM, CM]) =>
+              VdomNode:
+                renderFn
+                  .asInstanceOf[js.Function1[raw.buildLibCoreHeadersMod.HeaderContext[T, A], Node]](
+                    headerContext.toJs
+                  )
 
     /** WARNING: This mutates the object in-place. */
     def setHeader(
-      header: js.UndefOr[String | (raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode)]
-    ): Single[T, A] = Single {
-      toJs.header = header match
-        case s: String                                                        => s
-        case fn: (raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode) =>
-          fn.andThen(_.rawNode)
-        case _                                                                => ()
+      header: js.UndefOr[String | (HeaderContext[T, A, TM, CM] => VdomNode)]
+    ): Single[T, A, TM, CM] = Single {
+      toJs.header = header.map:
+        _ match
+          case s: String                                           => s
+          case renderFn: (HeaderContext[T, A, TM, CM] => VdomNode) =>
+            (headerContextJs: raw.buildLibCoreHeadersMod.HeaderContext[T, A]) =>
+              renderFn(HeaderContext(headerContextJs)).rawNode
       toJs
     }
 
-    lazy val cell: js.UndefOr[raw.buildLibCoreCellMod.CellContext[T, A] => VdomNode] =
-      toJs.cell.map(_.andThen(VdomNode(_)))
+    lazy val cell: js.UndefOr[CellContext[T, A, TM, CM] => VdomNode] =
+      toJs.cell.map(renderFn => cellContext => VdomNode(renderFn(cellContext.toJs)))
 
     /** WARNING: This mutates the object in-place. */
     def setCell(
-      cell: js.UndefOr[raw.buildLibCoreCellMod.CellContext[T, A] => VdomNode]
-    ): Single[T, A] =
-      Single { toJs.cell = cell.map(_.andThen(_.rawNode)); toJs }
+      cell: js.UndefOr[CellContext[T, A, TM, CM] => VdomNode]
+    ): Single[T, A, TM, CM] =
+      Single {
+        toJs.cell =
+          cell.map(renderFn => cellContextJs => renderFn(CellContext(cellContextJs)).rawNode);
+        toJs
+      }
 
-    lazy val footer: js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode] =
-      toJs.footer.map(_.andThen(VdomNode(_)))
+    lazy val footer: js.UndefOr[HeaderContext[T, A, TM, CM] => VdomNode] =
+      toJs.footer.map: renderFn =>
+        (headerContext: HeaderContext[T, A, TM, CM]) =>
+          VdomNode:
+            renderFn
+              .asInstanceOf[js.Function1[raw.buildLibCoreHeadersMod.HeaderContext[T, A], Node]](
+                headerContext.toJs
+              )
 
     /** WARNING: This mutates the object in-place. */
     def setFooter(
-      footer: js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode]
-    ): Single[T, A] =
-      Single { toJs.footer = footer.map(_.andThen(_.rawNode)); toJs }
+      footer: js.UndefOr[HeaderContext[T, A, TM, CM] => VdomNode]
+    ): Single[T, A, TM, CM] = Single {
+      toJs.footer = footer.map: renderFn =>
+        headerContextJs => renderFn(HeaderContext(headerContextJs)).rawNode
+      toJs
+    }
 
-    lazy val meta: js.UndefOr[Any] = toJs.meta
+    lazy val meta: js.UndefOr[CM] = toJs.meta
 
     /** WARNING: This mutates the object in-place. */
-    def setMeta(meta: Any): Single[T, A] = Single { toJs.meta = meta; toJs }
+    def setMeta(meta: CM): Single[T, A, TM, CM] = Single { toJs.meta = meta; toJs }
 
     // Column Sizing
     lazy val enableResizing: js.UndefOr[Boolean] = toJs.enableResizing
 
     /** WARNING: This mutates the object in-place. */
-    def setEnableResizing(enableResizing: js.UndefOr[Boolean]): Single[T, A] =
+    def setEnableResizing(enableResizing: js.UndefOr[Boolean]): Single[T, A, TM, CM] =
       Single { toJs.enableResizing = enableResizing; toJs }
 
     lazy val size: js.UndefOr[SizePx] = toJs.size.map(SizePx(_))
 
     /** WARNING: This mutates the object in-place. */
-    def setSize(size: js.UndefOr[SizePx]): Single[T, A] =
+    def setSize(size: js.UndefOr[SizePx]): Single[T, A, TM, CM] =
       Single { toJs.size = size.map(_.value); toJs }
 
     lazy val minSize: js.UndefOr[SizePx] = toJs.minSize.map(SizePx(_))
 
     /** WARNING: This mutates the object in-place. */
-    def setMinSize(minSize: js.UndefOr[SizePx]): Single[T, A] =
+    def setMinSize(minSize: js.UndefOr[SizePx]): Single[T, A, TM, CM] =
       Single { toJs.minSize = minSize.map(_.value); toJs }
 
     lazy val maxSize: js.UndefOr[SizePx] = toJs.maxSize.map(SizePx(_))
 
     /** WARNING: This mutates the object in-place. */
-    def setMaxSize(maxSize: js.UndefOr[SizePx]): Single[T, A] =
+    def setMaxSize(maxSize: js.UndefOr[SizePx]): Single[T, A, TM, CM] =
       Single { toJs.maxSize = maxSize.map(_.value); toJs }
 
     // Column Visibility
     lazy val enableHiding: js.UndefOr[Boolean] = toJs.enableHiding
 
     /** WARNING: This mutates the object in-place. */
-    def setEnableHiding(enableHiding: js.UndefOr[Boolean]): Single[T, A] =
+    def setEnableHiding(enableHiding: js.UndefOr[Boolean]): Single[T, A, TM, CM] =
       Single { toJs.enableHiding = enableHiding; toJs }
 
     // Sorting
     lazy val enableSorting: js.UndefOr[Boolean] = toJs.enableSorting
 
     /** WARNING: This mutates the object in-place. */
-    def setEnableSorting(enableSorting: js.UndefOr[Boolean]): Single[T, A] =
+    def setEnableSorting(enableSorting: js.UndefOr[Boolean]): Single[T, A, TM, CM] =
       Single { toJs.enableSorting = enableSorting; toJs }
 
     lazy val enableMultiSort: js.UndefOr[Boolean] = toJs.enableMultiSort
 
     /** WARNING: This mutates the object in-place. */
-    def setEnableMultiSort(enableMultiSort: js.UndefOr[Boolean]): Single[T, A] =
+    def setEnableMultiSort(enableMultiSort: js.UndefOr[Boolean]): Single[T, A, TM, CM] =
       Single { toJs.enableMultiSort = enableMultiSort; toJs }
 
     lazy val invertSorting: js.UndefOr[Boolean] = toJs.invertSorting
 
     /** WARNING: This mutates the object in-place. */
-    def setInvertSorting(invertSorting: js.UndefOr[Boolean]): Single[T, A] =
+    def setInvertSorting(invertSorting: js.UndefOr[Boolean]): Single[T, A, TM, CM] =
       Single { toJs.invertSorting = invertSorting; toJs }
 
     lazy val sortDescFirst: js.UndefOr[Boolean] = toJs.sortDescFirst
 
     /** WARNING: This mutates the object in-place. */
-    def setSortDescFirst(sortDescFirst: js.UndefOr[Boolean]): Single[T, A] =
+    def setSortDescFirst(sortDescFirst: js.UndefOr[Boolean]): Single[T, A, TM, CM] =
       Single { toJs.sortDescFirst = sortDescFirst; toJs }
 
     lazy val sortUndefined: js.UndefOr[UndefinedPriority] = // Baffingly, we need this cast.
       toJs.sortUndefined.map(v => UndefinedPriority.fromJs(v.asInstanceOf[UndefinedPriorityJs]))
 
     /** WARNING: This mutates the object in-place. */
-    def setSortUndefined(sortUndefined: js.UndefOr[UndefinedPriority]): Single[T, A] =
+    def setSortUndefined(sortUndefined: js.UndefOr[UndefinedPriority]): Single[T, A, TM, CM] =
       Single { toJs.sortUndefined = sortUndefined.map(_.toJs); toJs }
 
-    lazy val sortingFn: js.UndefOr[BuiltInSorting | SortingFn[T]] =
+    lazy val sortingFn: js.UndefOr[BuiltInSorting | SortingFn[T, TM]] =
       toJs.sortingFn.map(v =>
         js.typeOf(v) match
           case "string" => BuiltInSorting.fromJs(v.asInstanceOf[String])
           case fn       =>
-            (rowA: Row[T], rowB: Row[T], colId: ColumnId) =>
-              fn.asInstanceOf[raw.buildLibFeaturesSortingMod.SortingFn[T]](rowA.toJs,
-                                                                           rowB.toJs,
-                                                                           colId.value
+            (rowA: Row[T, TM], rowB: Row[T, TM], colId: ColumnId) =>
+              fn.asInstanceOf[raw.buildLibFeaturesSortingMod.SortingFn[T]](
+                rowA.toJs,
+                rowB.toJs,
+                colId.value
               ).toInt
       )
 
     /** WARNING: This mutates the object in-place. */
-    def setSortingFn(sortingFn: js.UndefOr[BuiltInSorting | SortingFn[T]]): Single[T, A] = Single {
-      toJs.sortingFn = sortingFn match
-        case builtIn: BuiltInSorting => builtIn.toJs
-        case fn                      =>
-          (rowA, rowB, colId) =>
-            fn.asInstanceOf[SortingFn[T]](Row(rowA), Row(rowB), ColumnId(colId)).toDouble
-      toJs
-    }
+    def setSortingFn(
+      sortingFn: js.UndefOr[BuiltInSorting | SortingFn[T, TM]]
+    ): Single[T, A, TM, CM] =
+      Single {
+        toJs.sortingFn = sortingFn match
+          case builtIn: BuiltInSorting => builtIn.toJs
+          case fn                      =>
+            (rowA, rowB, colId) =>
+              fn.asInstanceOf[SortingFn[T, TM]](Row(rowA), Row(rowB), ColumnId(colId)).toDouble
+        toJs
+      }
 
     /** WARNING: This mutates the object in-place. */
-    def sortableBuiltIn(builtIn: BuiltInSorting): Single[T, A] =
+    def sortableBuiltIn(builtIn: BuiltInSorting): Single[T, A, TM, CM] =
       this.setSortingFn(builtIn).setEnableSorting(true)
 
     /** WARNING: This mutates the object in-place. */
-    def sortableWith[B](f: (A, A) => Int): Single[T, A] =
-      val sbfn: SortingFn[T] = (r1, r2, col) => f(r1.getValue[A](col), r2.getValue[A](col))
+    def sortableWith[B](f: (A, A) => Int): Single[T, A, TM, CM] =
+      val sbfn: SortingFn[T, TM] = (r1, r2, col) => f(r1.getValue[A](col), r2.getValue[A](col))
       this.setSortingFn(sbfn).setEnableSorting(true)
 
     /** WARNING: This mutates the object in-place. */
-    def sortableBy[B](f: A => B)(using ordering: Ordering[B]): ColumnDef[T, A] =
+    def sortableBy[B](f: A => B)(using ordering: Ordering[B]): ColumnDef[T, A, TM, CM] =
       sortableWith((a1, a2) => ordering.compare(f(a1), f(a2)))
 
     /** WARNING: This mutates the object in-place. */
@@ -197,14 +220,17 @@ object ColumnDef:
   end Single
 
   object Single:
-    def apply[T, A](
+    type NoMeta[T, A]             = Single[T, A, Nothing, Nothing]
+    type WithTableMeta[T, A, TM]  = Single[T, A, TM, Nothing]
+    type WithColumnMeta[T, A, CM] = Single[T, A, Nothing, CM]
+
+    def apply[T, A, TM, CM](
       id:              ColumnId,
       accessor:        js.UndefOr[T => A] = js.undefined,
-      header:          js.UndefOr[String | (raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode)] =
-        js.undefined,
-      cell:            js.UndefOr[raw.buildLibCoreCellMod.CellContext[T, A] => VdomNode] = js.undefined,
-      footer:          js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode] = js.undefined,
-      meta:            js.UndefOr[Any] = js.undefined,
+      header:          js.UndefOr[String | (HeaderContext[T, A, TM, CM] => VdomNode)] = js.undefined,
+      cell:            js.UndefOr[CellContext[T, A, TM, CM] => VdomNode] = js.undefined,
+      footer:          js.UndefOr[HeaderContext[T, A, TM, CM] => VdomNode] = js.undefined,
+      meta:            js.UndefOr[CM] = js.undefined,
       // Column Sizing
       enableResizing:  js.UndefOr[Boolean] = js.undefined,
       size:            js.UndefOr[SizePx] = js.undefined,
@@ -218,11 +244,11 @@ object ColumnDef:
       invertSorting:   js.UndefOr[Boolean] = js.undefined,
       sortDescFirst:   js.UndefOr[Boolean] = js.undefined,
       sortUndefined:   js.UndefOr[UndefinedPriority] = js.undefined,
-      sortingFn:       js.UndefOr[BuiltInSorting | SortingFn[T]] = js.undefined
-    ): Single[T, A] = {
-      val p: ColumnDefJs[T, A] = new js.Object().asInstanceOf[ColumnDefJs[T, A]]
+      sortingFn:       js.UndefOr[BuiltInSorting | SortingFn[T, TM]] = js.undefined
+    ): Single[T, A, TM, CM] = { // TODO Check where TM is used???!?!?!?
+      val p: ColumnDefJs[T, A, TM, CM] = new js.Object().asInstanceOf[ColumnDefJs[T, A, TM, CM]]
       p.id = id.value
-      Single(p)
+      Single[T, A, TM, CM](p)
         .applyOrNot(accessor, _.setAccessor(_))
         .applyOrNot(header, _.setHeader(_))
         .applyOrNot(footer, _.setFooter(_))
@@ -242,103 +268,120 @@ object ColumnDef:
     }
   end Single
 
-  case class Group[T](private[table] val toJs: ColumnDefJs[T, Nothing])
-      extends ColumnDef[T, Nothing]:
+  case class Group[T, TM, CM](private[table] val toJs: ColumnDefJs[T, Nothing, TM, CM])
+      extends ColumnDef[T, Nothing, TM, CM]:
     lazy val id: ColumnId = ColumnId(toJs.id)
 
     /** WARNING: This mutates the object in-place. */
-    def setId(id: ColumnId): Group[T] = Group { toJs.id = id.value; toJs }
+    def setId(id: ColumnId): Group[T, TM, CM] = Group { toJs.id = id.value; toJs }
 
-    lazy val columns: List[ColumnDef[T, Any]] =
-      toJs.columns.map(_.toList).toOption.orEmpty.map(ColumnDef.fromJs[T, Any])
+    lazy val columns: List[ColumnDef[T, Any, TM, Any]] =
+      toJs.columns
+        .map(_.toList)
+        .toOption
+        .orEmpty
+        .map(ColumnDef.fromJs(_).asInstanceOf[ColumnDef[T, Any, TM, Any]])
 
     /** WARNING: This mutates the object in-place. */
-    def withColumns(columns: List[ColumnDef[T, Any]]): Group[T] =
+    def withColumns(columns: List[ColumnDef[T, Any, TM, Any]]): Group[T, TM, CM] =
       Group { toJs.columns = columns.map(_.toJs).toJSArray; toJs }
 
-    lazy val header
-      : js.UndefOr[String | (raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode)] =
-      toJs.header.map(v =>
+    lazy val header: js.UndefOr[String | (HeaderContext[T, Nothing, TM, CM] => VdomNode)] =
+      toJs.header.map: v =>
         js.typeOf(v) match
           case "string" => v.asInstanceOf[String]
-          case fn       =>
-            fn.asInstanceOf[js.Function1[raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing],
-                                         Node
-            ]].andThen(VdomNode(_))
-      )
+          case renderFn =>
+            (headerContext: HeaderContext[T, Nothing, TM, CM]) =>
+              VdomNode:
+                renderFn
+                  .asInstanceOf[js.Function1[
+                    raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing],
+                    Node
+                  ]](headerContext.toJs)
 
     /** WARNING: This mutates the object in-place. */
     def setHeader(
-      header: js.UndefOr[
-        String | (raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode)
-      ]
-    ): Group[T] = Group {
-      toJs.header = header match
-        case s: String                                                              => s
-        case fn: (raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode) =>
-          fn.andThen(_.rawNode)
-        case _                                                                      => ()
+      header: js.UndefOr[String | (HeaderContext[T, Nothing, TM, CM] => VdomNode)]
+    ): Group[T, TM, CM] = Group {
+      toJs.header = header.map:
+        _ match
+          case s: String                                                 => s
+          case renderFn: (HeaderContext[T, Nothing, TM, CM] => VdomNode) =>
+            (headerContextJs: raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing]) =>
+              renderFn(HeaderContext(headerContextJs)).rawNode
       toJs
     }
 
-    lazy val footer: js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode] =
-      toJs.footer.map(_.andThen(VdomNode(_)))
+    lazy val footer: js.UndefOr[HeaderContext[T, Nothing, TM, CM] => VdomNode] =
+      toJs.footer.map: renderFn =>
+        (headerContext: HeaderContext[T, Nothing, TM, CM]) =>
+          VdomNode:
+            renderFn
+              .asInstanceOf[js.Function1[
+                raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing],
+                Node
+              ]](headerContext.toJs)
 
     /** WARNING: This mutates the object in-place. */
     def setFooter(
-      footer: js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode]
-    ): Group[T] =
-      Group { toJs.footer = footer.map(_.andThen(_.rawNode)); toJs }
+      footer: js.UndefOr[HeaderContext[T, Nothing, TM, CM] => VdomNode]
+    ): Group[T, TM, CM] =
+      Group {
+        toJs.footer = footer.map: renderFn =>
+          headerContextJs => renderFn(HeaderContext(headerContextJs)).rawNode
+        toJs
+      }
 
-    lazy val meta: js.UndefOr[Any] = toJs.meta
+    lazy val meta: js.UndefOr[CM] = toJs.meta
 
     /** WARNING: This mutates the object in-place. */
-    def setMeta(meta: Any): Group[T] = Group { toJs.meta = meta; toJs }
+    def setMeta(meta: CM): Group[T, TM, CM] = Group { toJs.meta = meta; toJs }
 
     // Column Sizing
     lazy val enableResizing: js.UndefOr[Boolean] = toJs.enableResizing
 
     /** WARNING: This mutates the object in-place. */
-    def setEnableResizing(enableResizing: js.UndefOr[Boolean]): Group[T] =
+    def setEnableResizing(enableResizing: js.UndefOr[Boolean]): Group[T, TM, CM] =
       Group { toJs.enableResizing = enableResizing; toJs }
 
     lazy val size: js.UndefOr[SizePx] = toJs.size.map(SizePx(_))
 
     /** WARNING: This mutates the object in-place. */
-    def setSize(size: js.UndefOr[SizePx]): Group[T] =
+    def setSize(size: js.UndefOr[SizePx]): Group[T, TM, CM] =
       Group { toJs.size = size.map(_.value); toJs }
 
     lazy val minSize: js.UndefOr[SizePx] = toJs.minSize.map(SizePx(_))
 
     /** WARNING: This mutates the object in-place. */
-    def setMinSize(minSize: js.UndefOr[SizePx]): Group[T] =
+    def setMinSize(minSize: js.UndefOr[SizePx]): Group[T, TM, CM] =
       Group { toJs.minSize = minSize.map(_.value); toJs }
 
     lazy val maxSize: js.UndefOr[SizePx] = toJs.maxSize.map(SizePx(_))
 
     /** WARNING: This mutates the object in-place. */
-    def setMaxSize(maxSize: js.UndefOr[SizePx]): Group[T] =
+    def setMaxSize(maxSize: js.UndefOr[SizePx]): Group[T, TM, CM] =
       Group { toJs.maxSize = maxSize.map(_.value); toJs }
 
     // Column Visibility
     lazy val enableHiding: js.UndefOr[Boolean] = toJs.enableHiding
 
     /** WARNING: This mutates the object in-place. */
-    def setEnableHiding(enableHiding: js.UndefOr[Boolean]): Group[T] =
+    def setEnableHiding(enableHiding: js.UndefOr[Boolean]): Group[T, TM, CM] =
       Group { toJs.enableHiding = enableHiding; toJs }
 
   end Group
 
   object Group:
-    def apply[T](
+    type NoMeta[T]             = Group[T, Nothing, Nothing]
+    type WithTableMeta[T, TM]  = Group[T, TM, Nothing]
+    type WithColumnMeta[T, CM] = Group[T, Nothing, CM]
+
+    def apply[T, TM, CM](
       id:             ColumnId,
-      header:         js.UndefOr[
-        String | (raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode)
-      ] = js.undefined,
-      columns:        List[ColumnDef[T, Any]],
-      footer:         js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode] =
-        js.undefined,
-      meta:           js.UndefOr[Any] = js.undefined,
+      header:         js.UndefOr[String | (HeaderContext[T, Nothing, TM, CM] => VdomNode)] = js.undefined,
+      columns:        List[ColumnDef[T, ?, TM, ?]],
+      footer:         js.UndefOr[HeaderContext[T, Nothing, TM, CM] => VdomNode] = js.undefined,
+      meta:           js.UndefOr[CM] = js.undefined,
       // Column Sizing
       enableResizing: js.UndefOr[Boolean] = js.undefined,
       size:           js.UndefOr[SizePx] = js.undefined,
@@ -346,11 +389,12 @@ object ColumnDef:
       maxSize:        js.UndefOr[SizePx] = js.undefined,
       // Column Visibility
       enableHiding:   js.UndefOr[Boolean] = js.undefined
-    ): Group[T] = {
-      val p: ColumnDefJs[T, Nothing] = new js.Object().asInstanceOf[ColumnDefJs[T, Nothing]]
+    ): Group[T, TM, CM] = {
+      val p: ColumnDefJs[T, Nothing, TM, CM] =
+        new js.Object().asInstanceOf[ColumnDefJs[T, Nothing, TM, CM]]
       p.id = id.value
       p.columns = columns.map(_.toJs).toJSArray
-      Group(p)
+      Group[T, TM, CM](p)
         .applyOrNot(header, _.setHeader(_))
         .applyOrNot(meta, _.setMeta(_))
         .applyOrNot(enableResizing, _.setEnableResizing(_))
@@ -361,24 +405,29 @@ object ColumnDef:
     }
   end Group
 
-  private[table] def fromJs[T, A](colDef: ColumnDefJs[T, A]): ColumnDef[T, A] =
+  private[table] def fromJs[T, A, TM, CM](
+    colDef: ColumnDefJs[T, A, TM, CM]
+  ): ColumnDef[T, A, TM, CM] =
     if (colDef.columns.isDefined)
-      Group(colDef.asInstanceOf[ColumnDefJs[T, Nothing]]).asInstanceOf[ColumnDef[T, A]]
+      Group(colDef.asInstanceOf[ColumnDefJs[T, Nothing, TM, CM]])
+        .asInstanceOf[ColumnDef[T, A, TM, CM]]
     else
       Single(colDef)
 
-  def apply[T]: Applied[T] =
-    new Applied[T]
+  def apply[T]: Applied[T, Nothing] =
+    new Applied[T, Nothing]
 
-  class Applied[T]:
+  object WithTableMeta:
+    def apply[T, TM]: Applied[T, TM] =
+      new Applied[T, TM]
+
+  class Applied[T, TM]:
     def apply[A](
       id:              ColumnId,
       accessor:        js.UndefOr[T => A] = js.undefined,
-      header:          js.UndefOr[String | (raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode)] =
-        js.undefined,
-      cell:            js.UndefOr[raw.buildLibCoreCellMod.CellContext[T, A] => VdomNode] = js.undefined,
-      footer:          js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, A] => VdomNode] = js.undefined,
-      meta:            js.UndefOr[Any] = js.undefined,
+      header:          js.UndefOr[String | (HeaderContext[T, A, TM, Nothing] => VdomNode)] = js.undefined,
+      cell:            js.UndefOr[CellContext[T, A, TM, Nothing] => VdomNode] = js.undefined,
+      footer:          js.UndefOr[HeaderContext[T, A, TM, Nothing] => VdomNode] = js.undefined,
       // Column Sizing
       enableResizing:  js.UndefOr[Boolean] = js.undefined,
       size:            js.UndefOr[SizePx] = js.undefined,
@@ -392,8 +441,88 @@ object ColumnDef:
       invertSorting:   js.UndefOr[Boolean] = js.undefined,
       sortDescFirst:   js.UndefOr[Boolean] = js.undefined,
       sortUndefined:   js.UndefOr[UndefinedPriority] = js.undefined,
-      sortingFn:       js.UndefOr[BuiltInSorting | SortingFn[T]] = js.undefined
-    ): Single[T, A] =
+      sortingFn:       js.UndefOr[BuiltInSorting | SortingFn[T, TM]] = js.undefined
+    ): Single[T, A, TM, Nothing] =
+      Single(
+        id,
+        accessor,
+        header,
+        cell,
+        footer,
+        js.undefined,
+        // Column Sizing
+        enableResizing,
+        size,
+        minSize,
+        maxSize,
+        // Column Visibility
+        enableHiding,
+        // Sorting
+        enableSorting,
+        enableMultiSort,
+        invertSorting,
+        sortDescFirst,
+        sortUndefined,
+        sortingFn
+      )
+
+    def group(
+      id:             ColumnId,
+      header:         js.UndefOr[String | (HeaderContext[T, Nothing, TM, Nothing] => VdomNode)] =
+        js.undefined,
+      columns:        List[ColumnDef[T, ?, TM, ?]],
+      footer:         js.UndefOr[HeaderContext[T, Nothing, TM, Nothing] => VdomNode] = js.undefined,
+      // Column Sizing
+      enableResizing: js.UndefOr[Boolean] = js.undefined,
+      size:           js.UndefOr[SizePx] = js.undefined,
+      minSize:        js.UndefOr[SizePx] = js.undefined,
+      maxSize:        js.UndefOr[SizePx] = js.undefined,
+      // Column Visibility
+      enableHiding:   js.UndefOr[Boolean] = js.undefined
+    ): Group[T, TM, Nothing] =
+      Group(
+        id,
+        header,
+        columns,
+        footer,
+        js.undefined,
+        enableResizing,
+        size,
+        minSize,
+        maxSize,
+        enableHiding
+      )
+
+    def WithColumnMeta[CM]: AppliedWithColumnMeta[T, TM, CM] =
+      new AppliedWithColumnMeta[T, TM, CM]
+  end Applied
+
+  object Applied:
+    type NoMeta[T] = Applied[T, Nothing]
+
+  class AppliedWithColumnMeta[T, TM, CM]:
+    def apply[A](
+      id:              ColumnId,
+      accessor:        js.UndefOr[T => A] = js.undefined,
+      header:          js.UndefOr[String | (HeaderContext[T, A, TM, CM] => VdomNode)] = js.undefined,
+      cell:            js.UndefOr[CellContext[T, A, TM, CM] => VdomNode] = js.undefined,
+      footer:          js.UndefOr[HeaderContext[T, A, TM, CM] => VdomNode] = js.undefined,
+      meta:            js.UndefOr[CM] = js.undefined,
+      // Column Sizing
+      enableResizing:  js.UndefOr[Boolean] = js.undefined,
+      size:            js.UndefOr[SizePx] = js.undefined,
+      minSize:         js.UndefOr[SizePx] = js.undefined,
+      maxSize:         js.UndefOr[SizePx] = js.undefined,
+      // Column Visibility
+      enableHiding:    js.UndefOr[Boolean] = js.undefined,
+      // Sorting
+      enableSorting:   js.UndefOr[Boolean] = js.undefined,
+      enableMultiSort: js.UndefOr[Boolean] = js.undefined,
+      invertSorting:   js.UndefOr[Boolean] = js.undefined,
+      sortDescFirst:   js.UndefOr[Boolean] = js.undefined,
+      sortUndefined:   js.UndefOr[UndefinedPriority] = js.undefined,
+      sortingFn:       js.UndefOr[BuiltInSorting | SortingFn[T, TM]] = js.undefined
+    ): Single[T, A, TM, CM] =
       Single(
         id,
         accessor,
@@ -417,15 +546,12 @@ object ColumnDef:
         sortingFn
       )
 
-    def group(
+    def group[TM](
       id:             ColumnId,
-      header:         js.UndefOr[
-        String | (raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode)
-      ] = js.undefined,
-      columns:        List[ColumnDef[T, Any]],
-      footer:         js.UndefOr[raw.buildLibCoreHeadersMod.HeaderContext[T, Nothing] => VdomNode] =
-        js.undefined,
-      meta:           js.UndefOr[Any] = js.undefined,
+      header:         js.UndefOr[String | (HeaderContext[T, Nothing, TM, CM] => VdomNode)] = js.undefined,
+      columns:        List[ColumnDef[T, Any, TM, Any]],
+      footer:         js.UndefOr[HeaderContext[T, Nothing, TM, CM] => VdomNode] = js.undefined,
+      meta:           js.UndefOr[CM] = js.undefined,
       // Column Sizing
       enableResizing: js.UndefOr[Boolean] = js.undefined,
       size:           js.UndefOr[SizePx] = js.undefined,
@@ -433,8 +559,8 @@ object ColumnDef:
       maxSize:        js.UndefOr[SizePx] = js.undefined,
       // Column Visibility
       enableHiding:   js.UndefOr[Boolean] = js.undefined
-    ): Group[T] =
+    ): Group[T, TM, CM] =
       Group(id, header, columns, footer, meta, enableResizing, size, minSize, maxSize, enableHiding)
-  end Applied
+  end AppliedWithColumnMeta
 
 end ColumnDef

--- a/tanstack-table/src/main/scala/lucuma/react/table/ColumnPinningPosition.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/ColumnPinningPosition.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.table
+
+import lucuma.typed.tanstackTableCore.buildLibFeaturesPinningMod as raw
+
+enum ColumnPinningPosition(private[table] val toJs: raw.ColumnPinningPosition):
+  case Left  extends ColumnPinningPosition(raw.ColumnPinningPosition.left)
+  case Right extends ColumnPinningPosition(raw.ColumnPinningPosition.right)

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
@@ -8,54 +8,43 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.SizePx
 import lucuma.react.common.*
-import lucuma.typed.tanstackTableCore as raw
 import lucuma.typed.tanstackVirtualCore as rawVirtual
 import org.scalajs.dom.HTMLElement
 
 import scalajs.js
 
-final case class HTMLTable[T](
-  table:         Table[T],
+final case class HTMLTable[T, TM](
+  table:         Table[T, TM],
   tableMod:      TagMod = TagMod.empty,
   headerMod:     TagMod = TagMod.empty,
-  headerRowMod:  raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod =
-    (_: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T]) => TagMod.empty,
-  headerCellMod: raw.buildLibTypesMod.Header[T, Any] => TagMod =
-    (_: raw.buildLibTypesMod.Header[T, Any]) => TagMod.empty,
+  headerRowMod:  HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
+  headerCellMod: Header[T, Any, TM, Any] => TagMod = (_: Header[T, Any, TM, Any]) => TagMod.empty,
   bodyMod:       TagMod = TagMod.empty,
-  rowMod:        raw.buildLibTypesMod.Row[T] => TagMod = (_: raw.buildLibTypesMod.Row[T]) => TagMod.empty,
-  cellMod:       raw.buildLibTypesMod.Cell[T, Any] => TagMod = (_: raw.buildLibTypesMod.Cell[T, Any]) =>
-    TagMod.empty,
+  rowMod:        Row[T, TM] => TagMod = (_: Row[T, TM]) => TagMod.empty,
+  cellMod:       Cell[T, Any, TM, Any] => TagMod = (_: Cell[T, Any, TM, Any]) => TagMod.empty,
   footerMod:     TagMod = TagMod.empty,
-  footerRowMod:  raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod =
-    (_: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T]) => TagMod.empty,
-  footerCellMod: raw.buildLibTypesMod.Header[T, Any] => TagMod =
-    (_: raw.buildLibTypesMod.Header[T, Any]) => TagMod.empty,
+  footerRowMod:  HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
+  footerCellMod: Header[T, Any, TM, Any] => TagMod = (_: Header[T, Any, TM, Any]) => TagMod.empty,
   emptyMessage:  VdomNode = EmptyVdom
 ) extends ReactFnProps(HTMLTable.component)
-    with HTMLTableProps[T]
+    with HTMLTableProps[T, TM]
 
-final case class HTMLVirtualizedTable[T](
-  table:         Table[T],
+final case class HTMLVirtualizedTable[T, TM](
+  table:         Table[T, TM],
   estimateSize:  Int => SizePx,
   // Table options
   containerMod:  TagMod = TagMod.empty,
   containerRef:  js.UndefOr[Ref.Simple[HTMLElement]] = js.undefined,
   tableMod:      TagMod = TagMod.empty,
   headerMod:     TagMod = TagMod.empty,
-  headerRowMod:  raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod =
-    (_: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T]) => TagMod.empty,
-  headerCellMod: raw.buildLibTypesMod.Header[T, Any] => TagMod =
-    (_: raw.buildLibTypesMod.Header[T, Any]) => TagMod.empty,
+  headerRowMod:  HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
+  headerCellMod: Header[T, Any, TM, Any] => TagMod = (_: Header[T, Any, TM, Any]) => TagMod.empty,
   bodyMod:       TagMod = TagMod.empty,
-  rowMod:        raw.buildLibTypesMod.Row[T] => TagMod = (_: raw.buildLibTypesMod.Row[T]) => TagMod.empty,
-  cellMod:       raw.buildLibTypesMod.Cell[T, Any] => TagMod = (_: raw.buildLibTypesMod.Cell[T, Any]) =>
-    TagMod.empty,
+  rowMod:        Row[T, TM] => TagMod = (_: Row[T, TM]) => TagMod.empty,
+  cellMod:       Cell[T, Any, TM, Any] => TagMod = (_: Cell[T, Any, TM, Any]) => TagMod.empty,
   footerMod:     TagMod = TagMod.empty,
-  footerRowMod:  raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod =
-    (_: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T]) => TagMod.empty,
-  footerCellMod: raw.buildLibTypesMod.Header[T, Any] => TagMod =
-    (_: raw.buildLibTypesMod.Header[T, Any]) => TagMod.empty,
+  footerRowMod:  HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
+  footerCellMod: Header[T, Any, TM, Any] => TagMod = (_: Header[T, Any, TM, Any]) => TagMod.empty,
   emptyMessage:  VdomNode = EmptyVdom,
 
   // Virtual options
@@ -65,10 +54,10 @@ final case class HTMLVirtualizedTable[T](
   virtualizerRef:   js.UndefOr[NonEmptyRef.Simple[Option[HTMLTableVirtualizer]]] = js.undefined,
   debugVirtualizer: js.UndefOr[Boolean] = js.undefined
 ) extends ReactFnProps(HTMLVirtualizedTable.component)
-    with HTMLVirtualizedTableProps[T]
+    with HTMLVirtualizedTableProps[T, TM]
 
-final case class HTMLAutoHeightVirtualizedTable[T](
-  table:             Table[T],
+final case class HTMLAutoHeightVirtualizedTable[T, TM](
+  table:             Table[T, TM],
   estimateSize:      Int => SizePx,
   // Table options
   containerMod:      TagMod = TagMod.empty,
@@ -76,19 +65,14 @@ final case class HTMLAutoHeightVirtualizedTable[T](
   innerContainerMod: TagMod = TagMod.empty,
   tableMod:          TagMod = TagMod.empty,
   headerMod:         TagMod = TagMod.empty,
-  headerRowMod:      raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod =
-    (_: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T]) => TagMod.empty,
-  headerCellMod:     raw.buildLibTypesMod.Header[T, Any] => TagMod =
-    (_: raw.buildLibTypesMod.Header[T, Any]) => TagMod.empty,
+  headerRowMod:      HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
+  headerCellMod:     Header[T, Any, TM, Any] => TagMod = (_: Header[T, Any, TM, Any]) => TagMod.empty,
   bodyMod:           TagMod = TagMod.empty,
-  rowMod:            raw.buildLibTypesMod.Row[T] => TagMod = (_: raw.buildLibTypesMod.Row[T]) => TagMod.empty,
-  cellMod:           raw.buildLibTypesMod.Cell[T, Any] => TagMod = (_: raw.buildLibTypesMod.Cell[T, Any]) =>
-    TagMod.empty,
+  rowMod:            Row[T, TM] => TagMod = (_: Row[T, TM]) => TagMod.empty,
+  cellMod:           Cell[T, Any, TM, Any] => TagMod = (_: Cell[T, Any, TM, Any]) => TagMod.empty,
   footerMod:         TagMod = TagMod.empty,
-  footerRowMod:      raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod =
-    (_: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T]) => TagMod.empty,
-  footerCellMod:     raw.buildLibTypesMod.Header[T, Any] => TagMod =
-    (_: raw.buildLibTypesMod.Header[T, Any]) => TagMod.empty,
+  footerRowMod:      HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
+  footerCellMod:     Header[T, Any, TM, Any] => TagMod = (_: Header[T, Any, TM, Any]) => TagMod.empty,
   emptyMessage:      VdomNode = EmptyVdom,
   // Virtual options
   overscan:          js.UndefOr[Int] = js.undefined,
@@ -97,20 +81,21 @@ final case class HTMLAutoHeightVirtualizedTable[T](
   virtualizerRef:    js.UndefOr[NonEmptyRef.Simple[Option[HTMLTableVirtualizer]]] = js.undefined,
   debugVirtualizer:  js.UndefOr[Boolean] = js.undefined
 ) extends ReactFnProps(HTMLAutoHeightVirtualizedTable.component)
-    with HTMLAutoHeightVirtualizedTableProps[T]
+    with HTMLAutoHeightVirtualizedTableProps[T, TM]
 
 private val baseHTMLRenderer: HTMLTableRenderer[Any] =
   new HTMLTableRenderer[Any] {}
 
 object HTMLTable:
-  private val component = HTMLTableRenderer.componentBuilder[Any, HTMLTable](baseHTMLRenderer)
+  private val component = HTMLTableRenderer.componentBuilder[Any, Any, HTMLTable](baseHTMLRenderer)
 
 object HTMLVirtualizedTable:
   private val component =
-    HTMLTableRenderer.componentBuilderVirtualized[Any, HTMLVirtualizedTable](baseHTMLRenderer)
+    HTMLTableRenderer.componentBuilderVirtualized[Any, Any, HTMLVirtualizedTable](baseHTMLRenderer)
 
 object HTMLAutoHeightVirtualizedTable:
   private val component =
-    HTMLTableRenderer.componentBuilderAutoHeightVirtualized[Any, HTMLAutoHeightVirtualizedTable](
-      baseHTMLRenderer
-    )
+    HTMLTableRenderer
+      .componentBuilderAutoHeightVirtualized[Any, Any, HTMLAutoHeightVirtualizedTable](
+        baseHTMLRenderer
+      )

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -46,24 +46,24 @@ trait HTMLTableRenderer[T]:
   protected val SortAscIndicator: VdomNode  = "↑"
   protected val SortDescIndicator: VdomNode = "↓"
 
-  protected def sortIndicator[T](col: raw.buildLibTypesMod.Column[T, ?]): VdomNode =
-    col.getIsSorted().asInstanceOf[Boolean | String] match
-      case sorted: String =>
+  protected def sortIndicator[T, TM](col: Column[T, ?, TM, ?]): VdomNode =
+    col
+      .getIsSorted()
+      .fold(if (col.getCanSort()) SortableIndicator else EmptyVdom): sortDirection =>
         val index   = if (col.getSortIndex() > 0) (col.getSortIndex() + 1).toInt.toString else ""
-        val ascDesc = if (sorted == "desc") SortDescIndicator else SortAscIndicator
+        val ascDesc =
+          if (sortDirection == SortDirection.Descending) SortDescIndicator else SortAscIndicator
         <.span(ascDesc, <.small(index))
-      case _              =>
-        if (col.getCanSort()) SortableIndicator else EmptyVdom
 
-  protected def resizer[T](
-    header:     raw.buildLibTypesMod.Header[T, ?],
+  protected def resizer[T, TM](
+    header:     Header[T, ?, TM, ?],
     resizeMode: Option[ColumnResizeMode],
     sizingInfo: ColumnSizingInfo
   ): VdomNode =
     if (header.column.getCanResize())
       <.div(
-        ^.onMouseDown ==> (e => Callback(header.getResizeHandler()(e))),
-        ^.onTouchStart ==> (e => Callback(header.getResizeHandler()(e))),
+        ^.onMouseDown ==> header.getResizeHandler(),
+        ^.onTouchStart ==> header.getResizeHandler(),
         ^.onClick ==> (_.stopPropagationCB),
         ResizerClass,
         IsResizingColClass.when(header.column.getIsResizing()),
@@ -77,25 +77,19 @@ trait HTMLTableRenderer[T]:
       )(ResizerContent)
     else EmptyVdom
 
-  def render[T](
-    table:         Table[T],
-    rows:          js.Array[raw.buildLibTypesMod.Row[T]],
+  def render[T, TM](
+    table:         Table[T, TM],
+    rows:          List[Row[T, TM]],
     tableMod:      TagMod = TagMod.empty,
     headerMod:     TagMod = TagMod.empty,
-    headerRowMod:  raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod =
-      (_: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T]) => TagMod.empty,
-    headerCellMod: raw.buildLibTypesMod.Header[T, Any] => TagMod =
-      (_: raw.buildLibTypesMod.Header[T, Any]) => TagMod.empty,
+    headerRowMod:  HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
+    headerCellMod: Header[T, Any, TM, Any] => TagMod = (_: Header[T, Any, TM, Any]) => TagMod.empty,
     bodyMod:       TagMod = TagMod.empty,
-    rowMod:        raw.buildLibTypesMod.Row[T] => TagMod = (_: raw.buildLibTypesMod.Row[T]) =>
-      TagMod.empty,
-    cellMod:       raw.buildLibTypesMod.Cell[T, Any] => TagMod = (_: raw.buildLibTypesMod.Cell[T, Any]) =>
-      TagMod.empty,
+    rowMod:        Row[T, TM] => TagMod = (_: Row[T, TM]) => TagMod.empty,
+    cellMod:       Cell[T, Any, TM, Any] => TagMod = (_: Cell[T, Any, TM, Any]) => TagMod.empty,
     footerMod:     TagMod = TagMod.empty,
-    footerRowMod:  raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod =
-      (_: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T]) => TagMod.empty,
-    footerCellMod: raw.buildLibTypesMod.Header[T, Any] => TagMod =
-      (_: raw.buildLibTypesMod.Header[T, Any]) => TagMod.empty,
+    footerRowMod:  HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
+    footerCellMod: Header[T, Any, TM, Any] => TagMod = (_: Header[T, Any, TM, Any]) => TagMod.empty,
     indexOffset:   Int = 0,
     paddingTop:    Option[Int] = none,
     paddingBottom: Option[Int] = none,
@@ -116,7 +110,7 @@ trait HTMLTableRenderer[T]:
               headerGroup.headers
                 .exists(header =>
                   js.typeOf(
-                    header.column.columnDef
+                    header.column.columnDef.toJs
                       .asInstanceOf[raw.buildLibCoreHeadersMod.HeaderContext[T, Any]]
                       .header
                   ) != "undefined"
@@ -134,13 +128,13 @@ trait HTMLTableRenderer[T]:
                       headerCellMod(header),
                       header.column
                         .getToggleSortingHandler()
-                        .map(handler => ^.onClick ==> (e => Callback(handler(e))))
+                        .map(handler => ^.onClick ==> handler)
                         .whenDefined
                     )(
                       TagMod.unless(header.isPlaceholder)(
                         React.Fragment(
                           rawReact.mod.flexRender(
-                            header.column.columnDef
+                            header.column.columnDef.toJs
                               .asInstanceOf[raw.buildLibCoreHeadersMod.HeaderContext[T, Any]]
                               .header
                               .asInstanceOf[rawReact.mod.Renderable[
@@ -148,6 +142,7 @@ trait HTMLTableRenderer[T]:
                               ]],
                             header
                               .getContext()
+                              .toJs
                               .asInstanceOf[raw.buildLibCoreHeadersMod.HeaderContext[T, Any]]
                           ),
                           sortIndicator(header.column),
@@ -160,6 +155,7 @@ trait HTMLTableRenderer[T]:
                       )
                     )
                   )
+                  .toTagMod
               )
             )
           )
@@ -196,7 +192,7 @@ trait HTMLTableRenderer[T]:
               TbodyTrClass,
               TbodyTrEvenClass.when((index + indexOffset) % 2 =!= 0),
               rowMod(row),
-              ^.key := row.id
+              ^.key := row.id.value
             )(
               row
                 .getVisibleCells()
@@ -204,19 +200,23 @@ trait HTMLTableRenderer[T]:
                   <.td(
                     TbodyTdClass,
                     cellMod(cell),
-                    ^.key := cell.id
+                    ^.key := cell.id.value
                   )(
-                    rawReact.mod.flexRender(
-                      cell.column.columnDef.cell
-                        .asInstanceOf[rawReact.mod.Renderable[
-                          raw.buildLibCoreCellMod.CellContext[T, Any]
-                        ]],
-                      cell.getContext()
-                    )
+                    cell.column.columnDef match
+                      case colDef @ ColumnDef.Single[T, Any, TM, Any](_) =>
+                        rawReact.mod.flexRender(
+                          colDef.toJs.cell
+                            .asInstanceOf[rawReact.mod.Renderable[
+                              raw.buildLibCoreCellMod.CellContext[T, Any]
+                            ]],
+                          cell.getContext().toJs
+                        )
                   )
                 )
+                .toTagMod
             ),
           )
+          .toTagMod
       )(
         paddingBottom
           .filter(_ > 1)
@@ -237,25 +237,33 @@ trait HTMLTableRenderer[T]:
           .map(footerGroup =>
             TagMod.when(
               footerGroup.headers
-                .exists(footer => js.typeOf(footer.column.columnDef.footer) != "undefined")
+                .exists(footer =>
+                  js.typeOf(
+                    footer.column.columnDef.toJs
+                      .asInstanceOf[raw.buildLibCoreHeadersMod.HeaderContext[T, Any]]
+                      .header
+                  ) != "undefined"
+                )
             )(
               <.tr(TfootTrClass, footerRowMod(footerGroup))(^.key := footerGroup.id)(
-                footerGroup.headers.map(footer =>
-                  <.th(TfootThClass, footerCellMod(footer))(
-                    ^.key     := footer.id,
-                    ^.colSpan := footer.colSpan.toInt
-                  )(
-                    TagMod.unless(footer.isPlaceholder)(
-                      rawReact.mod.flexRender(
-                        footer.column.columnDef.footer
-                          .asInstanceOf[rawReact.mod.Renderable[
-                            raw.buildLibCoreHeadersMod.HeaderContext[T, Any]
-                          ]],
-                        footer.getContext()
+                footerGroup.headers
+                  .map(footer =>
+                    <.th(TfootThClass, footerCellMod(footer))(
+                      ^.key     := footer.id,
+                      ^.colSpan := footer.colSpan.toInt
+                    )(
+                      TagMod.unless(footer.isPlaceholder)(
+                        rawReact.mod.flexRender(
+                          footer.column.columnDef.toJs.footer
+                            .asInstanceOf[rawReact.mod.Renderable[
+                              raw.buildLibCoreHeadersMod.HeaderContext[T, Any]
+                            ]],
+                          footer.getContext().toJs
+                        )
                       )
                     )
                   )
-                )
+                  .toTagMod
               )
             )
           )
@@ -264,8 +272,8 @@ trait HTMLTableRenderer[T]:
     )
 
 object HTMLTableRenderer:
-  def componentBuilder[T, Props <: HTMLTableProps[_]](renderer: HTMLTableRenderer[T]) =
-    ScalaFnComponent[Props[T]](props =>
+  def componentBuilder[T, M, Props <: HTMLTableProps[_, _]](renderer: HTMLTableRenderer[T]) =
+    ScalaFnComponent[Props[T, M]](props =>
       renderer.render(
         props.table,
         props.table.getRowModel().rows,
@@ -283,11 +291,11 @@ object HTMLTableRenderer:
       )
     )
 
-  def componentBuilderVirtualized[T, Props <: HTMLVirtualizedTableProps[_]](
+  def componentBuilderVirtualized[T, M, Props <: HTMLVirtualizedTableProps[_, _]](
     renderer: HTMLTableRenderer[T]
   ) =
     ScalaFnComponent
-      .withHooks[Props[T]]
+      .withHooks[Props[T, M]]
       .useRefToVdom[HTMLDivElement]
       .useVirtualizerBy((props, ref) =>
         VirtualOptions(
@@ -312,7 +320,7 @@ object HTMLTableRenderer:
         <.div.withRef(ref)(^.overflowY.auto, props.containerMod)(
           renderer.render(
             props.table,
-            virtualizer.getVirtualItems().map(virtualItem => rows(virtualItem.index.toInt)),
+            virtualizer.getVirtualItems().toList.map(virtualItem => rows(virtualItem.index.toInt)),
             TagMod(props.tableMod, props.extraTableClasses),
             props.headerMod,
             props.headerRowMod,
@@ -331,11 +339,13 @@ object HTMLTableRenderer:
         )
       }
 
-  def componentBuilderAutoHeightVirtualized[T, Props <: HTMLAutoHeightVirtualizedTableProps[_]](
+  def componentBuilderAutoHeightVirtualized[T, M, Props <: HTMLAutoHeightVirtualizedTableProps[_,
+                                                                                               _
+  ]](
     renderer: HTMLTableRenderer[T]
   ) =
     ScalaFnComponent
-      .withHooks[Props[T]]
+      .withHooks[Props[T, M]]
       .useRefToVdom[HTMLDivElement]
       .localValBy((props, ownRef) => props.containerRef.getOrElse(ownRef)) // containerRef
       .useVirtualizerBy((props, _, containerRef) =>
@@ -379,7 +389,10 @@ object HTMLTableRenderer:
           )(
             renderer.render(
               props.table,
-              virtualizer.getVirtualItems().map(virtualItem => rows(virtualItem.index.toInt)),
+              virtualizer
+                .getVirtualItems()
+                .toList
+                .map(virtualItem => rows(virtualItem.index.toInt)),
               TagMod(props.tableMod, props.extraTableClasses),
               props.headerMod,
               props.headerRowMod,

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -116,12 +116,12 @@ trait HTMLTableRenderer[T]:
                   ) != "undefined"
                 )
             )(
-              <.tr(TheadTrClass, headerRowMod(headerGroup))(^.key := headerGroup.id)(
+              <.tr(TheadTrClass, headerRowMod(headerGroup))(^.key := headerGroup.id.value)(
                 headerGroup.headers
                   .map(header =>
                     <.th(
                       TheadThClass,
-                      ^.key     := header.id,
+                      ^.key     := header.id.value,
                       ^.colSpan := header.colSpan.toInt,
                       ^.width   := s"${header.getSize().toInt}px",
                       SortableColClass.when(header.column.getCanSort()),
@@ -245,11 +245,11 @@ trait HTMLTableRenderer[T]:
                   ) != "undefined"
                 )
             )(
-              <.tr(TfootTrClass, footerRowMod(footerGroup))(^.key := footerGroup.id)(
+              <.tr(TfootTrClass, footerRowMod(footerGroup))(^.key := footerGroup.id.value)(
                 footerGroup.headers
                   .map(footer =>
                     <.th(TfootThClass, footerCellMod(footer))(
-                      ^.key     := footer.id,
+                      ^.key     := footer.id.value,
                       ^.colSpan := footer.colSpan.toInt
                     )(
                       TagMod.unless(footer.isPlaceholder)(

--- a/tanstack-table/src/main/scala/lucuma/react/table/Header.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/Header.scala
@@ -1,0 +1,158 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.table
+
+import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react.ReactEvent
+import lucuma.typed.tanstackTableCore as raw
+
+case class Header[T, A, TM, CM] private[table] (
+  private[table] val toJs: raw.buildLibTypesMod.Header[T, A]
+):
+  /**
+   * The col-span for the header.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#colspan)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val colSpan: Int = toJs.colSpan.toInt
+
+  /**
+   * The header's associated column object.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#column)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val column: Column[T, A, TM, CM] = Column(toJs.column)
+
+  /**
+   * The depth of the header, zero-indexed based.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#depth)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val depth: Int = toJs.depth.toInt
+
+  /**
+   * Returns the rendering context (or props) for column-based components like headers, footers and
+   * filters.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#getcontext)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  def getContext(): HeaderContext[T, A, TM, CM] = HeaderContext(toJs.getContext())
+
+  /**
+   * Returns the leaf headers hierarchically nested under this header.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#getleafheaders)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  def getLeafHeaders(): List[Header[T, Any, TM, Any]] = toJs.getLeafHeaders().toList.map(Header(_))
+
+  /**
+   * The header's associated header group object.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#headergroup)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val headerGroup: HeaderGroup[T, TM] = HeaderGroup(toJs.headerGroup)
+
+  /**
+   * The unique identifier for the header.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#id)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val id: String = toJs.id
+
+  /**
+   * The index for the header within the header group.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#index)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val index: Int = toJs.index.toInt
+
+  /**
+   * A boolean denoting if the header is a placeholder header.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#isplaceholder)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val isPlaceholder: Boolean = toJs.isPlaceholder
+
+  /**
+   * If the header is a placeholder header, this will be a unique header ID that does not conflict
+   * with any other headers across the table.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#placeholderid)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val placeholderId: Option[String] = toJs.placeholderId.toOption
+
+  /**
+   * The row-span for the header.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#rowspan)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val rowSpan: Int = toJs.rowSpan.toInt
+
+  /**
+   * The header's hierarchical sub/child headers. Will be empty if the header's associated column is
+   * a leaf-column.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/core/header#subheaders)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  lazy val subHeaders: List[Header[T, Any, TM, Any]] =
+    toJs.subHeaders.toList.map(Header(_).asInstanceOf[Header[T, Any, TM, Any]])
+
+  // ColumnSizingHeader
+
+  /**
+   * Returns an event handler function that can be used to resize the header. It can be used as an:
+   *   - `onMouseDown` handler
+   *   - `onTouchStart` handler
+   *
+   * The dragging and release events are automatically handled for you.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getresizehandler)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  def getResizeHandler(): ReactEvent => Callback = e => Callback(toJs.getResizeHandler()(e))
+
+  /**
+   * Returns the current size of the header.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getsize)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  def getSize(): Double = toJs.getSize()
+
+  /**
+   * Returns the offset measurement along the row-axis (usually the x-axis for standard tables) for
+   * the header. This is effectively a sum of the offset measurements of all preceding headers.
+   * @link
+   *   [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getstart)
+   * @link
+   *   [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  def getStart(): Double = toJs.getStart()
+  def getStart(position: ColumnPinningPosition): Double = toJs.getStart(position.toJs)

--- a/tanstack-table/src/main/scala/lucuma/react/table/Header.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/Header.scala
@@ -72,7 +72,7 @@ case class Header[T, A, TM, CM] private[table] (
    * @link
    *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
    */
-  lazy val id: String = toJs.id
+  lazy val id: HeaderId = HeaderId(toJs.id)
 
   /**
    * The index for the header within the header group.
@@ -100,7 +100,7 @@ case class Header[T, A, TM, CM] private[table] (
    * @link
    *   [Guide](https://tanstack.com/table/v8/docs/guide/headers)
    */
-  lazy val placeholderId: Option[String] = toJs.placeholderId.toOption
+  lazy val placeholderId: Option[PlaceholderId] = toJs.placeholderId.toOption.map(PlaceholderId(_))
 
   /**
    * The row-span for the header.

--- a/tanstack-table/src/main/scala/lucuma/react/table/HeaderContext.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HeaderContext.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.table
+
+import lucuma.typed.tanstackTableCore as raw
+
+case class HeaderContext[T, A, TM, CM] private[table] (
+  private[table] val toJs: raw.buildLibCoreHeadersMod.HeaderContext[T, A]
+):
+  lazy val column: Column[T, A, TM, CM] = Column(toJs.column)
+
+  lazy val header: Header[T, A, TM, CM] = Header(toJs.header)
+
+  lazy val table: Table[T, TM] = Table(toJs.table)

--- a/tanstack-table/src/main/scala/lucuma/react/table/HeaderContext.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HeaderContext.scala
@@ -9,7 +9,5 @@ case class HeaderContext[T, A, TM, CM] private[table] (
   private[table] val toJs: raw.buildLibCoreHeadersMod.HeaderContext[T, A]
 ):
   lazy val column: Column[T, A, TM, CM] = Column(toJs.column)
-
   lazy val header: Header[T, A, TM, CM] = Header(toJs.header)
-
-  lazy val table: Table[T, TM] = Table(toJs.table)
+  lazy val table: Table[T, TM]          = Table(toJs.table)

--- a/tanstack-table/src/main/scala/lucuma/react/table/HeaderGroup.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HeaderGroup.scala
@@ -8,8 +8,6 @@ import lucuma.typed.tanstackTableCore as raw
 case class HeaderGroup[T, TM] private[table] (
   private[table] val toJs: raw.buildLibTypesMod.HeaderGroup[T]
 ):
-  lazy val depth: Int = toJs.depth.toInt
-
+  lazy val depth: Int                             = toJs.depth.toInt
   lazy val headers: List[Header[T, Any, TM, Any]] = toJs.headers.toList.map(Header(_))
-
-  lazy val id: String = toJs.id
+  lazy val id: HeaderGroupId                      = HeaderGroupId(toJs.id)

--- a/tanstack-table/src/main/scala/lucuma/react/table/HeaderGroup.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HeaderGroup.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.table
+
+import lucuma.typed.tanstackTableCore as raw
+
+case class HeaderGroup[T, TM] private[table] (
+  private[table] val toJs: raw.buildLibTypesMod.HeaderGroup[T]
+):
+  lazy val depth: Int = toJs.depth.toInt
+
+  lazy val headers: List[Header[T, Any, TM, Any]] = toJs.headers.toList.map(Header(_))
+
+  lazy val id: String = toJs.id

--- a/tanstack-table/src/main/scala/lucuma/react/table/HooksApiExt.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HooksApiExt.scala
@@ -7,28 +7,28 @@ import japgolly.scalajs.react.*
 
 object HooksApiExt:
   sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]):
-    final def useReactTable[T](
-      options: TableOptions[T]
+    final def useReactTable[T, M](
+      options: TableOptions[T, M]
     )(using
       step:    Step
-    ): step.Next[Table[T]] =
+    ): step.Next[Table[T, M]] =
       useReactTableBy(_ => options)
 
-    final def useReactTableBy[T](
-      options: Ctx => TableOptions[T]
+    final def useReactTableBy[T, M](
+      options: Ctx => TableOptions[T, M]
     )(using
       step:    Step
-    ): step.Next[Table[T]] =
+    ): step.Next[Table[T, M]] =
       api.customBy(ctx => TableHook.useTableHook(options(ctx)))
 
   final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
     api: HooksApi.Secondary[Ctx, CtxFn, Step]
   ) extends Primary[Ctx, Step](api):
-    def useReactTableBy[T](
-      tableDefWithOptions: CtxFn[TableOptions[T]]
+    def useReactTableBy[T, M](
+      tableDefWithOptions: CtxFn[TableOptions[T, M]]
     )(implicit
       step:                Step
-    ): step.Next[Table[T]] =
+    ): step.Next[Table[T, M]] =
       super.useReactTableBy(step.squash(tableDefWithOptions)(_))
 
 trait HooksApiExt:

--- a/tanstack-table/src/main/scala/lucuma/react/table/Row.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/Row.scala
@@ -11,24 +11,27 @@ import org.scalajs.dom
 import scalajs.js.JSConverters.*
 
 // Missing: Filters
-case class Row[T](private[table] val toJs: raw.buildLibTypesMod.Row[T]):
-  lazy val depth: Int                       = toJs.depth.toInt
-  lazy val id: RowId                        = RowId(toJs.id)
-  lazy val index: Int                       = toJs.index.toInt
-  lazy val original: T                      = toJs.original
-  lazy val originalSubRows: Option[List[T]] = toJs.originalSubRows.toOption.map(_.toList)
-  lazy val subRows: List[Row[T]]            = toJs.subRows.toList.map(Row(_))
-  def getAllCells(): List[Cell[T, Any]]     = toJs.getAllCells().toList.map(Cell(_))
-  def getLeafRows(): List[Row[T]]           = toJs.getLeafRows().toList.map(Row(_))
+case class Row[T, TM] private[table] (private[table] val toJs: raw.buildLibTypesMod.Row[T]):
+  lazy val depth: Int                            = toJs.depth.toInt
+  lazy val id: RowId                             = RowId(toJs.id)
+  lazy val index: Int                            = toJs.index.toInt
+  lazy val original: T                           = toJs.original
+  lazy val originalSubRows: Option[List[T]]      = toJs.originalSubRows.toOption.map(_.toList)
+  lazy val subRows: List[Row[T, TM]]             = toJs.subRows.toList.map(Row(_))
+  def getAllCells(): List[Cell[T, Any, TM, Any]] = toJs.getAllCells().toList.map(Cell(_))
+  def getLeafRows(): List[Row[T, TM]]            = toJs.getLeafRows().toList.map(Row(_))
   def getValue[V](columnId: ColumnId): V = toJs.getValue(columnId.value)
 
   // Visibility
-  def getVisibleCells(): List[Cell[T, Any]] = toJs.getVisibleCells().toList.map(Cell(_))
+  def getVisibleCells(): List[Cell[T, Any, TM, Any]] = toJs.getVisibleCells().toList.map(Cell(_))
 
   // Column Pinning
-  def getCenterVisibleCells(): List[Cell[T, Any]] = toJs.getCenterVisibleCells().toList.map(Cell(_))
-  def getLeftVisibleCells(): List[Cell[T, Any]]   = toJs.getLeftVisibleCells().toList.map(Cell(_))
-  def getRightVisibleCells(): List[Cell[T, Any]]  = toJs.getRightVisibleCells().toList.map(Cell(_))
+  def getCenterVisibleCells(): List[Cell[T, Any, TM, Any]] =
+    toJs.getCenterVisibleCells().toList.map(Cell(_))
+  def getLeftVisibleCells(): List[Cell[T, Any, TM, Any]]   =
+    toJs.getLeftVisibleCells().toList.map(Cell(_))
+  def getRightVisibleCells(): List[Cell[T, Any, TM, Any]]  =
+    toJs.getRightVisibleCells().toList.map(Cell(_))
 
   // Row Grouping
   def getIsGrouped(): Boolean               = toJs.getIsGrouped()
@@ -50,6 +53,6 @@ case class Row[T](private[table] val toJs: raw.buildLibTypesMod.Row[T]):
   // Expanded Rows
   def getCanExpand(): Boolean              = toJs.getCanExpand()
   def getIsExpanded(): Boolean             = toJs.getIsExpanded()
-  def getToggleExpandedHandler(): Callback = Callback(toJs.getToggleExpandedHandler())
+  def getToggleExpandedHandler(): Callback = Callback(toJs.getToggleExpandedHandler()())
   def toggleExpanded(): Callback           = Callback(toJs.toggleExpanded())
   def toggleExpanded(expanded: Boolean): Callback = Callback(toJs.toggleExpanded(expanded))

--- a/tanstack-table/src/main/scala/lucuma/react/table/RowModel.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/RowModel.scala
@@ -8,10 +8,8 @@ import lucuma.typed.tanstackTableCore as raw
 case class RowModel[T, TM] private[table] (
   private[table] val toJs: raw.buildLibTypesMod.RowModel[T]
 ):
-  lazy val flatRows: List[Row[T, TM]] = toJs.flatRows.map(Row(_)).toList
-
-  lazy val rows: List[Row[T, TM]] = toJs.rows.map(Row(_)).toList
-
+  lazy val flatRows: List[Row[T, TM]]       = toJs.flatRows.map(Row(_)).toList
+  lazy val rows: List[Row[T, TM]]           = toJs.rows.map(Row(_)).toList
   lazy val rowsById: Map[RowId, Row[T, TM]] =
     toJs.rowsById.toMap.map: (k, v) =>
       RowId(k) -> Row[T, TM](v)

--- a/tanstack-table/src/main/scala/lucuma/react/table/RowModel.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/RowModel.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.table
+
+import lucuma.typed.tanstackTableCore as raw
+
+case class RowModel[T, TM] private[table] (
+  private[table] val toJs: raw.buildLibTypesMod.RowModel[T]
+):
+  lazy val flatRows: List[Row[T, TM]] = toJs.flatRows.map(Row(_)).toList
+
+  lazy val rows: List[Row[T, TM]] = toJs.rows.map(Row(_)).toList
+
+  lazy val rowsById: Map[RowId, Row[T, TM]] =
+    toJs.rowsById.toMap.map: (k, v) =>
+      RowId(k) -> Row[T, TM](v)

--- a/tanstack-table/src/main/scala/lucuma/react/table/Table.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/Table.scala
@@ -14,68 +14,72 @@ import org.scalajs.dom
 import scalajs.js.JSConverters.*
 
 // Missing: ColumnOrder, ColumnPinning, Filters, Grouping, Pagination
-case class Table[T](private[table] val toJs: raw.buildLibTypesMod.Table[T]):
-  def getAllColumns(): List[Column[T, Any]]               = toJs.getAllColumns().toList.map(Column(_))
-  def getAllFlatColumns(): List[Column[T, Any]]           = toJs.getAllFlatColumns().toList.map(Column(_))
-  def getAllLeafColumns(): List[Column[T, Any]]           = toJs.getAllLeafColumns().toList.map(Column(_))
-  def getColumn(columnId: String): Option[Column[T, Any]] =
+case class Table[T, TM] private[table] (private[table] val toJs: raw.buildLibTypesMod.Table[T]):
+  def getAllColumns(): List[Column[T, Any, TM, Any]]               = toJs.getAllColumns().toList.map(Column(_))
+  def getAllFlatColumns(): List[Column[T, Any, TM, Any]]           =
+    toJs.getAllFlatColumns().toList.map(Column(_))
+  def getAllLeafColumns(): List[Column[T, Any, TM, Any]]           =
+    toJs.getAllLeafColumns().toList.map(Column(_))
+  def getColumn(columnId: String): Option[Column[T, Any, TM, Any]] =
     toJs.getColumn(columnId).toOption.map(Column(_))
-  def getCoreRowModel(): raw.buildLibTypesMod.RowModel[T] = toJs.getCoreRowModel()
-  def getRow(id: String): Row[T] = Row(toJs.getRow(id))
-  def getRowModel(): raw.buildLibTypesMod.RowModel[T] = toJs.getRowModel()
-  def getState(): TableState                          = TableState(toJs.getState())
-  lazy val initialState: TableState                   = TableState(toJs.initialState)
-  lazy val options: TableOptions[T]                   =
-    TableOptions.fromJs(toJs.options.asInstanceOf[TableOptionsJs[T]])
-  def reset(): Callback                               = Callback(toJs.reset())
+  def getCoreRowModel(): RowModel[T, TM]                           = RowModel(toJs.getCoreRowModel())
+  def getRow(id: String): Row[T, TM] = Row(toJs.getRow(id))
+  def getRowModel(): RowModel[T, TM]    = RowModel(toJs.getRowModel())
+  def getState(): TableState            = TableState(toJs.getState())
+  lazy val initialState: TableState     = TableState(toJs.initialState)
+  lazy val options: TableOptions[T, TM] =
+    TableOptions.fromJs(toJs.options.asInstanceOf[TableOptionsJs[T, TM]])
+  def reset(): Callback                 = Callback(toJs.reset())
   def setState(value: TableState): Callback = Callback(toJs.setState(value.toJs))
   def modState(f: Endo[TableState]): Callback =
     Callback(toJs.setState(rawState => f(TableState(rawState)).toJs))
 
   // Headers
-  def getCenterFlatHeaders(): List[raw.buildLibTypesMod.Header[T, Any]]  =
-    toJs.getCenterFlatHeaders().toList
-  def getCenterFooterGroups(): List[raw.buildLibTypesMod.HeaderGroup[T]] =
-    toJs.getCenterFooterGroups().toList
-  def getCenterHeaderGroups(): List[raw.buildLibTypesMod.HeaderGroup[T]] =
-    toJs.getCenterHeaderGroups().toList
-  def getCenterLeafHeaders(): List[raw.buildLibTypesMod.Header[T, Any]]  =
-    toJs.getCenterLeafHeaders().toList
-  def getFlatHeaders(): List[raw.buildLibTypesMod.Header[T, Any]]        = toJs.getFlatHeaders().toList
-  def getFooterGroups(): List[raw.buildLibTypesMod.HeaderGroup[T]]       = toJs.getFooterGroups().toList
-  def getHeaderGroups(): List[raw.buildLibTypesMod.HeaderGroup[T]]       = toJs.getHeaderGroups().toList
-  def getLeafHeaders(): List[raw.buildLibTypesMod.Header[T, Any]]        = toJs.getLeafHeaders().toList
-  def getLeftFlatHeaders(): List[raw.buildLibTypesMod.Header[T, Any]]    =
-    toJs.getLeftFlatHeaders().toList
-  def getLeftFooterGroups(): List[raw.buildLibTypesMod.HeaderGroup[T]]   =
-    toJs.getLeftFooterGroups().toList
-  def getLeftHeaderGroups(): List[raw.buildLibTypesMod.HeaderGroup[T]]   =
-    toJs.getLeftHeaderGroups().toList
-  def getLeftLeafHeaders(): List[raw.buildLibTypesMod.Header[T, Any]]    =
-    toJs.getLeftLeafHeaders().toList
-  def getRightFlatHeaders(): List[raw.buildLibTypesMod.Header[T, Any]]   =
-    toJs.getRightFlatHeaders().toList
-  def getRightFooterGroups(): List[raw.buildLibTypesMod.HeaderGroup[T]]  =
-    toJs.getRightFooterGroups().toList
-  def getRightHeaderGroups(): List[raw.buildLibTypesMod.HeaderGroup[T]]  =
-    toJs.getRightHeaderGroups().toList
-  def getRightLeafHeaders(): List[raw.buildLibTypesMod.Header[T, Any]]   =
-    toJs.getRightLeafHeaders().toList
+  def getCenterFlatHeaders(): List[Header[T, Any, TM, Any]] =
+    toJs.getCenterFlatHeaders().toList.map(Header(_))
+  def getCenterFooterGroups(): List[HeaderGroup[T, TM]]     =
+    toJs.getCenterFooterGroups().toList.map(HeaderGroup(_))
+  def getCenterHeaderGroups(): List[HeaderGroup[T, TM]]     =
+    toJs.getCenterHeaderGroups().toList.map(HeaderGroup(_))
+  def getCenterLeafHeaders(): List[Header[T, Any, TM, Any]] =
+    toJs.getCenterLeafHeaders().toList.map(Header(_))
+  def getFlatHeaders(): List[Header[T, Any, TM, Any]]       = toJs.getFlatHeaders().toList.map(Header(_))
+  def getFooterGroups(): List[HeaderGroup[T, TM]]           =
+    toJs.getFooterGroups().toList.map(HeaderGroup(_))
+  def getHeaderGroups(): List[HeaderGroup[T, TM]]           =
+    toJs.getHeaderGroups().toList.map(HeaderGroup(_))
+  def getLeafHeaders(): List[Header[T, Any, TM, Any]]       = toJs.getLeafHeaders().toList.map(Header(_))
+  def getLeftFlatHeaders(): List[Header[T, Any, TM, Any]]   =
+    toJs.getLeftFlatHeaders().toList.map(Header(_))
+  def getLeftFooterGroups(): List[HeaderGroup[T, TM]]       =
+    toJs.getLeftFooterGroups().toList.map(HeaderGroup(_))
+  def getLeftHeaderGroups(): List[HeaderGroup[T, TM]]       =
+    toJs.getLeftHeaderGroups().toList.map(HeaderGroup(_))
+  def getLeftLeafHeaders(): List[Header[T, Any, TM, Any]]   =
+    toJs.getLeftLeafHeaders().toList.map(Header(_))
+  def getRightFlatHeaders(): List[Header[T, Any, TM, Any]]  =
+    toJs.getRightFlatHeaders().toList.map(Header(_))
+  def getRightFooterGroups(): List[HeaderGroup[T, TM]]      =
+    toJs.getRightFooterGroups().toList.map(HeaderGroup(_))
+  def getRightHeaderGroups(): List[HeaderGroup[T, TM]]      =
+    toJs.getRightHeaderGroups().toList.map(HeaderGroup(_))
+  def getRightLeafHeaders(): List[Header[T, Any, TM, Any]]  =
+    toJs.getRightLeafHeaders().toList.map(Header(_))
 
   // Visibility
-  def getCenterVisibleLeafColumns(): List[Column[T, Any]]                          =
+  def getCenterVisibleLeafColumns(): List[Column[T, Any, TM, Any]]                 =
     toJs.getCenterVisibleLeafColumns().toList.map(Column(_))
   def getIsAllColumnsVisible(): Boolean                                            = toJs.getIsAllColumnsVisible()
   def getIsSomeColumnsVisible(): Boolean                                           = toJs.getIsSomeColumnsVisible()
-  def getLeftVisibleLeafColumns(): List[Column[T, Any]]                            =
+  def getLeftVisibleLeafColumns(): List[Column[T, Any, TM, Any]]                   =
     toJs.getLeftVisibleLeafColumns().toList.map(Column(_))
-  def getRightVisibleLeafColumns(): List[Column[T, Any]]                           =
+  def getRightVisibleLeafColumns(): List[Column[T, Any, TM, Any]]                  =
     toJs.getRightVisibleLeafColumns().toList.map(Column(_))
   def getToggleAllColumnsVisibilityHandler(): SyntheticEvent[dom.Node] => Callback =
     e => Callback(toJs.getToggleAllColumnsVisibilityHandler()(e))
-  def getVisibleFlatColumns(): List[Column[T, Any]]                                =
+  def getVisibleFlatColumns(): List[Column[T, Any, TM, Any]]                       =
     toJs.getVisibleFlatColumns().toList.map(Column(_))
-  def getVisibleLeafColumns(): List[Column[T, Any]]                                =
+  def getVisibleLeafColumns(): List[Column[T, Any, TM, Any]]                       =
     toJs.getVisibleLeafColumns().toList.map(Column(_))
   def resetColumnVisibility(): Callback                                            = Callback(toJs.resetColumnVisibility())
   def resetColumnVisibility(defaultState: Boolean): Callback                       =
@@ -89,9 +93,9 @@ case class Table[T](private[table] val toJs: raw.buildLibTypesMod.Table[T]):
     Callback(toJs.toggleAllColumnsVisible(value))
 
   // Sorting
-  def getPreSortedRowModel(): raw.buildLibTypesMod.RowModel[T] = toJs.getPreSortedRowModel()
-  def getSortedRowModel(): raw.buildLibTypesMod.RowModel[T]    = toJs.getSortedRowModel()
-  def resetSorting(): Callback                                 = Callback(toJs.resetSorting())
+  def getPreSortedRowModel(): RowModel[T, TM] = RowModel(toJs.getPreSortedRowModel())
+  def getSortedRowModel(): RowModel[T, TM]    = RowModel(toJs.getSortedRowModel())
+  def resetSorting(): Callback                = Callback(toJs.resetSorting())
   def resetSorting(defaultState: Boolean): Callback = Callback(toJs.resetSorting(defaultState))
   def setSorting(value:          Sorting): Callback = Callback(toJs.setSorting(value.toJs))
   def modSorting(f: Endo[Sorting]): Callback =
@@ -119,10 +123,10 @@ case class Table[T](private[table] val toJs: raw.buildLibTypesMod.Table[T]):
   // Expanded
   def getCanSomeRowsExpand(): Boolean                                         = toJs.getCanSomeRowsExpand()
   def getExpandedDepth(): Int                                                 = toJs.getExpandedDepth().toInt
-  def getExpandedRowModel(): raw.buildLibTypesMod.RowModel[T]                 = toJs.getExpandedRowModel()
+  def getExpandedRowModel(): RowModel[T, TM]                                  = RowModel(toJs.getExpandedRowModel())
   def getIsAllRowsExpanded(): Boolean                                         = toJs.getIsAllRowsExpanded()
   def getIsSomeRowsExpanded(): Boolean                                        = toJs.getIsSomeRowsExpanded()
-  def getPreExpandedRowModel(): raw.buildLibTypesMod.RowModel[T]              = toJs.getPreExpandedRowModel()
+  def getPreExpandedRowModel(): RowModel[T, TM]                               = RowModel(toJs.getPreExpandedRowModel())
   def getToggleAllRowsExpandedHandler(): SyntheticEvent[dom.Node] => Callback =
     e => Callback(toJs.getToggleAllRowsExpandedHandler()(e))
   def resetExpanded(): Callback                                               = Callback(toJs.resetExpanded())
@@ -135,16 +139,14 @@ case class Table[T](private[table] val toJs: raw.buildLibTypesMod.Table[T]):
     Callback(toJs.toggleAllRowsExpanded(expanded))
 
   // RowSelection
-  def getFilteredSelectedRowModel(): raw.buildLibTypesMod.RowModel[T]             =
-    toJs.getFilteredSelectedRowModel()
-  def getGroupedSelectedRowModel(): raw.buildLibTypesMod.RowModel[T]              =
-    toJs.getGroupedSelectedRowModel()
+  def getFilteredSelectedRowModel(): RowModel[T, TM]                              = RowModel(toJs.getFilteredSelectedRowModel())
+  def getGroupedSelectedRowModel(): RowModel[T, TM]                               = RowModel(toJs.getGroupedSelectedRowModel())
   def getIsAllPageRowsSelected(): Boolean                                         = toJs.getIsAllPageRowsSelected()
   def getIsAllRowsSelected(): Boolean                                             = toJs.getIsAllRowsSelected()
   def getIsSomePageRowsSelected(): Boolean                                        = toJs.getIsSomePageRowsSelected()
   def getIsSomeRowsSelected(): Boolean                                            = toJs.getIsSomeRowsSelected()
-  def getPreSelectedRowModel(): raw.buildLibTypesMod.RowModel[T]                  = toJs.getPreSelectedRowModel()
-  def getSelectedRowModel(): raw.buildLibTypesMod.RowModel[T]                     = toJs.getSelectedRowModel()
+  def getPreSelectedRowModel(): RowModel[T, TM]                                   = RowModel(toJs.getPreSelectedRowModel())
+  def getSelectedRowModel(): RowModel[T, TM]                                      = RowModel(toJs.getSelectedRowModel())
   def getToggleAllPageRowsSelectedHandler(): SyntheticEvent[dom.Node] => Callback =
     e => Callback(toJs.getToggleAllPageRowsSelectedHandler()(e))
   def getToggleAllRowsSelectedHandler(): SyntheticEvent[dom.Node] => Callback     =

--- a/tanstack-table/src/main/scala/lucuma/react/table/TableHook.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/TableHook.scala
@@ -14,13 +14,13 @@ import scala.scalajs.js.annotation.JSImport
 object TableHook:
   @JSImport("@tanstack/react-table", "useReactTable")
   @js.native
-  private def useReactTableJs[T](options: TableOptionsJs[T]): raw.buildLibTypesMod.Table[T] =
+  private def useReactTableJs[T, M](options: TableOptionsJs[T, M]): raw.buildLibTypesMod.Table[T] =
     js.native
 
-  def useTableHook[T] =
-    CustomHook[TableOptions[T]]
+  def useTableHook[T, M] =
+    CustomHook[TableOptions[T, M]]
       .useMemoBy(_.columns)(input => _ => input.columnsJs)
       .useMemoBy(_.input.data)(ctx => _ => ctx.input.dataJs)
       .buildReturning { (options, cols, rows) =>
-        Table(useReactTableJs[T](options.toJs(cols, rows)))
+        Table[T, M](useReactTableJs[T, M](options.toJs(cols, rows)))
       }

--- a/tanstack-table/src/main/scala/lucuma/react/table/facade/ColumnDefJS.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/facade/ColumnDefJS.scala
@@ -8,16 +8,16 @@ import lucuma.typed.tanstackTableCore as raw
 
 import scalajs.js
 
-trait ColumnDefJs[T, A] extends js.Object:
+trait ColumnDefJs[T, A, TM, CM] extends js.Object:
   var id: String
   var header: js.UndefOr[
     String | js.Function1[raw.buildLibCoreHeadersMod.HeaderContext[T, A], Node]
   ]
   var accessorFn: js.UndefOr[js.Function1[T, A]]
   var cell: js.UndefOr[js.Function1[raw.buildLibCoreCellMod.CellContext[T, A], Node]]
-  var columns: js.UndefOr[js.Array[ColumnDefJs[T, Any]]]
+  var columns: js.UndefOr[js.Array[ColumnDefJs[T, ?, TM, ?]]]
   var footer: js.UndefOr[js.Function1[raw.buildLibCoreHeadersMod.HeaderContext[T, A], Node]]
-  var meta: js.UndefOr[Any]
+  var meta: js.UndefOr[CM]
 
   // Column Sizing
   var enableResizing: js.UndefOr[Boolean] = js.undefined

--- a/tanstack-table/src/main/scala/lucuma/react/table/facade/TableOptionsJS.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/facade/TableOptionsJS.scala
@@ -7,9 +7,10 @@ import lucuma.typed.tanstackTableCore as raw
 
 import scalajs.js
 
-trait TableOptionsJs[T] extends js.Object:
-  var columns: js.Array[ColumnDefJs[T, ?]]
+trait TableOptionsJs[T, TM] extends js.Object:
+  var columns: js.Array[ColumnDefJs[T, ?, TM, ?]]
   var data: js.Array[T]
+
   var getCoreRowModel: js.Function1[raw.buildLibTypesMod.Table[T], js.Function0[
     raw.buildLibTypesMod.RowModel[T]
   ]]
@@ -20,6 +21,7 @@ trait TableOptionsJs[T] extends js.Object:
   var renderFallbackValue: js.UndefOr[Any]                                                        = js.undefined
   var state: js.UndefOr[raw.anon.PartialTableState]                                               = js.undefined
   var initialState: js.UndefOr[raw.buildLibTypesMod.InitialTableState]                            = js.undefined
+  var meta: js.UndefOr[TM]                                                                        = js.undefined
 
   // Column Sizing // TODO Rest of the properties
   var enableColumnResizing: js.UndefOr[Boolean]                                          = js.undefined

--- a/tanstack-table/src/main/scala/lucuma/react/table/package.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/package.scala
@@ -25,6 +25,21 @@ package object table extends HooksApiExt:
     inline def apply(value: String): CellId                  = value
     extension (opaqueValue: CellId) inline def value: String = opaqueValue
 
+  opaque type HeaderId = String
+  object HeaderId:
+    inline def apply(value: String): HeaderId                  = value
+    extension (opaqueValue: HeaderId) inline def value: String = opaqueValue
+
+  opaque type PlaceholderId = String
+  object PlaceholderId:
+    inline def apply(value: String): PlaceholderId                  = value
+    extension (opaqueValue: PlaceholderId) inline def value: String = opaqueValue
+
+  opaque type HeaderGroupId = String
+  object HeaderGroupId:
+    inline def apply(value: String): HeaderGroupId                  = value
+    extension (opaqueValue: HeaderGroupId) inline def value: String = opaqueValue
+
   given renderJSArray[A](using ev: A => TagMod): Conversion[js.Array[A], TagMod] =
     new Conversion {
       def apply(x: js.Array[A]): TagMod = TagMod.fromTraversableOnce(x.map(ev))

--- a/tanstack-table/src/main/scala/lucuma/react/table/package.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/package.scala
@@ -4,12 +4,11 @@
 package lucuma.react
 
 import japgolly.scalajs.react.vdom.TagMod
-import lucuma.typed.tanstackTableCore as raw
 
 import scalajs.js
 
 package object table extends HooksApiExt:
-  type SortingFn[T] = (Row[T], Row[T], ColumnId) => Int
+  type SortingFn[T, TM] = (Row[T, TM], Row[T, TM], ColumnId) => Int
 
   opaque type ColumnId = String
   object ColumnId:
@@ -25,9 +24,6 @@ package object table extends HooksApiExt:
   object CellId:
     inline def apply(value: String): CellId                  = value
     extension (opaqueValue: CellId) inline def value: String = opaqueValue
-
-  extension [T, A](cellCtx: raw.buildLibCoreCellMod.CellContext[T, A])
-    def value: A = cellCtx.getValue().asInstanceOf[A]
 
   given renderJSArray[A](using ev: A => TagMod): Conversion[js.Array[A], TagMod] =
     new Conversion {

--- a/tanstack-table/src/main/scala/lucuma/react/table/props.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/props.scala
@@ -11,25 +11,24 @@ import japgolly.scalajs.react.vdom.VdomNode
 import lucuma.react.SizePx
 import lucuma.react.common.style.Css
 import lucuma.react.virtual.facade.Virtualizer
-import lucuma.typed.tanstackTableCore as raw
 import lucuma.typed.tanstackVirtualCore as rawVirtual
 import org.scalajs.dom.Element
 import org.scalajs.dom.HTMLElement
 
 import scalajs.js
 
-trait HTMLTableProps[T]:
-  def table: Table[T]
+trait HTMLTableProps[T, TM]:
+  def table: Table[T, TM]
   def tableMod: TagMod
   def headerMod: TagMod
-  def headerRowMod: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod
-  def headerCellMod: raw.buildLibTypesMod.Header[T, Any] => TagMod
+  def headerRowMod: HeaderGroup[T, TM] => TagMod
+  def headerCellMod: Header[T, Any, TM, Any] => TagMod
   def bodyMod: TagMod
-  def rowMod: raw.buildLibTypesMod.Row[T] => TagMod
-  def cellMod: raw.buildLibTypesMod.Cell[T, Any] => TagMod
+  def rowMod: Row[T, TM] => TagMod
+  def cellMod: Cell[T, Any, TM, Any] => TagMod
   def footerMod: TagMod
-  def footerRowMod: raw.buildLibCoreHeadersMod.CoreHeaderGroup[T] => TagMod
-  def footerCellMod: raw.buildLibTypesMod.Header[T, Any] => TagMod
+  def footerRowMod: HeaderGroup[T, TM] => TagMod
+  def footerCellMod: Header[T, Any, TM, Any] => TagMod
   def emptyMessage: VdomNode
 
   // Allow subtypes to mixin other classes
@@ -37,7 +36,7 @@ trait HTMLTableProps[T]:
 
 type HTMLTableVirtualizer = Virtualizer[HTMLElement, Element]
 
-trait HTMLVirtualizedTableProps[T] extends HTMLTableProps[T]:
+trait HTMLVirtualizedTableProps[T, M] extends HTMLTableProps[T, M]:
   def estimateSize: Int => SizePx
   // Table options
   def containerMod: TagMod
@@ -49,5 +48,5 @@ trait HTMLVirtualizedTableProps[T] extends HTMLTableProps[T]:
   def virtualizerRef: js.UndefOr[NonEmptyRef.Simple[Option[HTMLTableVirtualizer]]]
   def debugVirtualizer: js.UndefOr[Boolean]
 
-trait HTMLAutoHeightVirtualizedTableProps[T] extends HTMLVirtualizedTableProps[T]:
+trait HTMLAutoHeightVirtualizedTableProps[T, M] extends HTMLVirtualizedTableProps[T, M]:
   def innerContainerMod: TagMod


### PR DESCRIPTION
The previous version of the facade exposed some `raw` types.

The new version only exposes Scala types, which have now been type-parameterized with table meta (`TM`) and column meta (`CM`). These allow passing data to cell renderers without redefining the columns, which caused all components to remount.