### PR TITLE
Fix to chart race condition.

### DIFF
--- a/highcharts/src/main/scala/lucuma/react/highcharts/Chart.scala
+++ b/highcharts/src/main/scala/lucuma/react/highcharts/Chart.scala
@@ -78,6 +78,10 @@ object Chart:
                   Callback(chart.update(options))
             }
       .useEffectOnMountBy: (_, _, chartRef) =>
-        CallbackTo(chartRef.get.map(_.foreach(_.destroy()))) // Destroy at unmount
+        CallbackTo(
+          chartRef.value.fold(Callback.empty)(chart =>
+            chartRef.set(none) >> Callback(chart.destroy()) // Destroy at unmount
+          )
+        )
       .render: (props, containerRef, chartRef) =>
         <.div(props.containerMod).withRef(containerRef)


### PR DESCRIPTION
Setting `chartRef` to null when destroying the chart seems to fix the problem with strict mode and double clicking on the target table. I added logging and everything seems to be constructed and destructed the correct number of times.

This does NOT solve the `TypeError: Cannot read properties of undefined (reading '0')` errors for the Semester Plot in Explore where it is trying to load the data in the `ElevationSemesterPlot` component after the `onCreate` event. These occur when using StrictMode because data is being loaded into a destroyed chart. However, this only logs the messages to the console and does not break Explore. If I minimized/maximized the elevation plot over and over again I was able to break explore in the same data loading code, but it was not easy to accomplish.

Also, setting `allowUpdates = false` in Chart in the semester plot does not work properly. If you try to switch sites or semesters Explore crashes. The error occurs in the call to `chart.destroy`, but I think it is actually a result of the same data loading method noted above.