### PR TITLE
Ref types for tables matching the new resizer

### DIFF
--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTable.scala
@@ -34,7 +34,7 @@ final case class HTMLVirtualizedTable[T, TM](
   estimateSize:  Int => SizePx,
   // Table options
   containerMod:  TagMod = TagMod.empty,
-  containerRef:  js.UndefOr[Ref.Simple[HTMLElement]] = js.undefined,
+  containerRef:  js.UndefOr[Ref.ToVdom[HTMLElement]] = js.undefined,
   tableMod:      TagMod = TagMod.empty,
   headerMod:     TagMod = TagMod.empty,
   headerRowMod:  HeaderGroup[T, TM] => TagMod = (_: HeaderGroup[T, TM]) => TagMod.empty,
@@ -61,7 +61,7 @@ final case class HTMLAutoHeightVirtualizedTable[T, TM](
   estimateSize:      Int => SizePx,
   // Table options
   containerMod:      TagMod = TagMod.empty,
-  containerRef:      js.UndefOr[Ref.Simple[HTMLElement]] = js.undefined,
+  containerRef:      js.UndefOr[Ref.ToVdom[HTMLElement]] = js.undefined,
   innerContainerMod: TagMod = TagMod.empty,
   tableMod:          TagMod = TagMod.empty,
   headerMod:         TagMod = TagMod.empty,

--- a/tanstack-table/src/main/scala/lucuma/react/table/props.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/props.scala
@@ -40,7 +40,7 @@ trait HTMLVirtualizedTableProps[T, M] extends HTMLTableProps[T, M]:
   def estimateSize: Int => SizePx
   // Table options
   def containerMod: TagMod
-  def containerRef: js.UndefOr[Ref.Simple[HTMLElement]]
+  def containerRef: js.UndefOr[Ref.ToVdom[HTMLElement]]
   // Virtual options
   def overscan: js.UndefOr[Int]
   def getItemKey: js.UndefOr[Int => rawVirtual.mod.Key]


### PR DESCRIPTION
We now create the ref for the resizer using `useRefToVdom`. This aligns the type for the table renderer.