### PR TITLE
Update UndefinedPriorityJs for table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.67"
+ThisBuild / tlBaseVersion       := "0.68"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/tanstack-table/src/main/scala/lucuma/react/table/UndefinedPriority.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/UndefinedPriority.scala
@@ -6,13 +6,17 @@ package lucuma.react.table
 import lucuma.react.table.facade.UndefinedPriorityJs
 
 enum UndefinedPriority(private[table] val toJs: UndefinedPriorityJs):
-  case Tied   extends UndefinedPriority(false)
-  case Higher extends UndefinedPriority(-1)
-  case Lower  extends UndefinedPriority(1)
+  case First extends UndefinedPriority(UndefinedPriorityJs.First)
+  case Last  extends UndefinedPriority(UndefinedPriorityJs.Last)
+  case Tied  extends UndefinedPriority(UndefinedPriorityJs.Tied)
+  case Min   extends UndefinedPriority(UndefinedPriorityJs.Min)
+  case Max   extends UndefinedPriority(UndefinedPriorityJs.Max)
 
 object UndefinedPriority:
   private[table] def fromJs(rawValue: UndefinedPriorityJs): UndefinedPriority =
-    rawValue match
-      case _: false => UndefinedPriority.Tied
-      case _: -1    => UndefinedPriority.Higher
-      case _: 1     => UndefinedPriority.Lower
+    (rawValue: Any) match
+      case UndefinedPriorityJs.First => First
+      case UndefinedPriorityJs.Last  => Last
+      case UndefinedPriorityJs.Tied  => Tied
+      case UndefinedPriorityJs.Min   => Min
+      case UndefinedPriorityJs.Max   => Max

--- a/tanstack-table/src/main/scala/lucuma/react/table/facade/package.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/facade/package.scala
@@ -3,4 +3,12 @@
 
 package lucuma.react.table.facade
 
-type UndefinedPriorityJs = false | -1 | 1
+type UndefinedPriorityJs = UndefinedPriorityJs.First.type | UndefinedPriorityJs.Last.type |
+  UndefinedPriorityJs.Tied.type | UndefinedPriorityJs.Min.type | UndefinedPriorityJs.Max.type
+
+object UndefinedPriorityJs:
+  val First: "first" = "first"
+  val Last: "last"   = "last"
+  val Tied: false    = false
+  val Min: -1        = -1
+  val Max: 1         = 1


### PR DESCRIPTION
Turns out `react-table` implemented `First` and `Last` options in v8.16.0. We don't have to do it manually anymore.