### PR TITLE
Render table footers when mod defined

### DIFF
--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -238,6 +238,7 @@ trait HTMLTableRenderer[T]:
           .exists: footerGroup =>
             footerGroup.headers.exists: header =>
               header.column.columnDef.footer.isDefined
+            || footerMod != TagMod.empty
       )(
         <.tfoot(TfootClass, footerMod)(
           table


### PR DESCRIPTION
Sometimes we don't have footers defined in columns but we do have a general footer in the `footerMod` parameter. When this happens, we have to render the footer.