### PR TITLE
Tables: apply column width throughout

### DIFF
--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -201,7 +201,8 @@ trait HTMLTableRenderer[T]:
                   <.td(
                     TbodyTdClass,
                     cellMod(cell),
-                    ^.key := cell.id.value
+                    ^.key   := cell.id.value,
+                    ^.width := s"${cell.column.getSize().value}px"
                   )(
                     cell.column.columnDef match
                       case colDef @ ColumnDef.Single[T, Any, TM, Any](_) =>
@@ -249,7 +250,8 @@ trait HTMLTableRenderer[T]:
                   .map(footer =>
                     <.td(TfootTdClass, footerCellMod(footer))(
                       ^.key     := footer.id.value,
-                      ^.colSpan := footer.colSpan.toInt
+                      ^.colSpan := footer.colSpan.toInt,
+                      ^.width   := s"${footer.getSize().toInt}px"
                     )(
                       TagMod.unless(footer.isPlaceholder)(
                         rawReact.mod.flexRender(

--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -165,18 +165,20 @@ trait HTMLTableRenderer[T]:
           .filter(_ > 1)
           .map(p =>
             <.tr(TbodyTrClass)(
-              <.td(
-                TbodyTdClass,
-                ^.colSpan := visibleColumnCount,
-                ^.height  := s"${p}px"
-              )
+              table
+                .getLeafHeaders()
+                .map: header =>
+                  <.td(TbodyTdClass)(
+                    ^.height := s"${p}px",
+                    ^.width  := s"${header.getSize().toInt}px"
+                  )
+                .toTagMod
             )
           )
           .whenDefined
       )(
         TagMod.when(rows.isEmpty)(
-          <.tr(
-            TbodyTrClass,
+          <.tr(TbodyTrClass)(
             <.td(
               EmptyMessage,
               TbodyTdClass,
@@ -224,11 +226,15 @@ trait HTMLTableRenderer[T]:
           .filter(_ > 1)
           .map(p =>
             <.tr(TbodyTrClass)(
-              <.td(
-                TbodyTdClass,
-                ^.colSpan := visibleColumnCount,
-                ^.height  := s"${p}px"
-              )
+              table
+                .getLeafHeaders()
+                .map: header =>
+                  <.td(
+                    TbodyTdClass,
+                    ^.height := s"${p}px",
+                    ^.width  := s"${header.getSize().toInt}px"
+                  )
+                .toTagMod
             )
           )
           .whenDefined


### PR DESCRIPTION
In the HTML table renderer, the defined column width was only applied to the header. This usually works, except if we decide to hide the header.

This PR applies the column width explicitly to every cell, including the footer.