### PR TITLE
Apply table cell width before custom mods

### DIFF
--- a/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/HTMLTableRenderer.scala
@@ -202,9 +202,9 @@ trait HTMLTableRenderer[T]:
                 .map(cell =>
                   <.td(
                     TbodyTdClass,
-                    cellMod(cell),
                     ^.key   := cell.id.value,
-                    ^.width := s"${cell.column.getSize().value}px"
+                    ^.width := s"${cell.column.getSize().value}px",
+                    cellMod(cell)
                   )(
                     cell.column.columnDef match
                       case colDef @ ColumnDef.Single[T, Any, TM, Any](_) =>


### PR DESCRIPTION
The last PR introduced a bug where it was no longer possible to render custom widths for table cells. In particular, we use this for the expanded rows in the sequence in observe: the expanded row is actually a cell with full width and tweaked positioning.

This PR fixes the issue by applying customizations after the column width.