### PR TITLE
Migrate to monadic hooks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.75"
+ThisBuild / tlBaseVersion       := "0.76"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 
@@ -28,7 +28,7 @@ val lucumaTypedV     = "0.7.0"
 val munitScalacheckV = "1.0.0"
 val munitV           = "1.0.3"
 val scalaJsDomV      = "2.8.0"
-val scalaJsReactV    = "3.0.0-beta6"
+val scalaJsReactV    = "3.0.0-beta8"
 val utestV           = "0.8.4"
 
 ThisBuild / crossScalaVersions := Seq("3.6.2")

--- a/prime-react/src/main/scala/lucuma/react/primereact/package.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/package.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.primereact
+
+import japgolly.scalajs.react.vdom.VdomNode
+import lucuma.typed.StBuildingComponent
+
+import scalajs.js
+
+// This seems to be necessary for the compiler to pick up ST's implicit conversion.
+given [A <: js.Object]: Conversion[StBuildingComponent[A], VdomNode] with
+  def apply(a: StBuildingComponent[A]): VdomNode = StBuildingComponent.make(a)


### PR DESCRIPTION
Only resizer facade has been migrated so far, mostly as proof-of-concept.