### PR TITLE
Enable compact component definition, fix useResize

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.77"
+ThisBuild / tlBaseVersion       := "0.78"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 

--- a/hotkeys-hooks/src/main/scala/lucuma/react/hotkeys/hooks.scala
+++ b/hotkeys-hooks/src/main/scala/lucuma/react/hotkeys/hooks.scala
@@ -12,7 +12,6 @@ object HooksDef {
   private def useReusableDeps[D: Reusability]: (() => D) => HookResult[(D, Int)] =
     CustomHook.reusableDeps[D].toHookResult
 
-  // This is withdeps... what is global???
   def useHotkeysWithDeps[D: Reusability](deps: => D)(props: D => UseHotkeysProps): HookResult[Ref] =
     useReusableDeps(() => deps).map: (d, rev) =>
       val p = props(d)

--- a/resize-detector-demo/src/main/scala/lucuma/react/resizeDetector/demo/HookDemo.scala
+++ b/resize-detector-demo/src/main/scala/lucuma/react/resizeDetector/demo/HookDemo.scala
@@ -10,22 +10,18 @@ import lucuma.react.common.*
 import lucuma.react.resizeDetector.*
 import lucuma.react.resizeDetector.hooks.*
 
-case class HookDemo() extends ReactFnProps(HookDemo.component)
+case class HookDemo() extends ReactFnProps(HookDemo)
 
-object HookDemo:
-  type Props = HookDemo
-
-  val component =
-    ScalaFnComponent
-      .withHooks[Props]
-      .useResizeDetector()
-      .useEffectBy((_, resize) => Callback(println(resize)))
-      .render { (_, resize) =>
-        <.div(
-          Css("resize-detector-demo")
-        )(
-          <.span("Hook demo"),
-          <.span(s"Width: ${resize.width.orEmpty}px"),
-          <.span(s"Height: ${resize.height.orEmpty}px")
-        ).withRef(resize.ref)
-      }
+object HookDemo
+    extends ReactFnComponent[HookDemo](props =>
+      for
+        resize <- useResizeDetector
+        _      <- useEffect(Callback(println(resize)))
+      yield <.div(
+        Css("resize-detector-demo")
+      )(
+        <.span("Hook demo"),
+        <.span(s"Width: ${resize.width.orEmpty}px"),
+        <.span(s"Height: ${resize.height.orEmpty}px")
+      ).withRef(resize.ref)
+    )

--- a/resize-detector/src/main/scala/lucuma/react/resizeDetector/hooks.scala
+++ b/resize-detector/src/main/scala/lucuma/react/resizeDetector/hooks.scala
@@ -29,9 +29,9 @@ object ResizeDetector {
     ] = js.native
   }
 
-  private val jsHook = HookResult.fromFunction(raw.useResizeObserver)
+  private final val jsHook = HookResult.fromFunction(raw.useResizeObserver)
 
-  def useResizeDetector(props: UseResizeDetectorProps): HookResult[UseResizeDetectorReturn] =
+  final def useResizeDetector(props: UseResizeDetectorProps): HookResult[UseResizeDetectorReturn] =
     for
       ref  <- useRefToVdom[HTMLElement]
       size <- useState(UseResizeDetectorReturn(none, none, ref))
@@ -48,7 +48,10 @@ object ResizeDetector {
               )
     yield size.value
 
-  val hook = CustomHook.fromHookResult(useResizeDetector)
+  inline final def useResizeDetector: HookResult[UseResizeDetectorReturn] =
+    useResizeDetector(UseResizeDetectorProps())
+
+  final val hook = CustomHook.fromHookResult(useResizeDetector(_))
 }
 
 object HooksApiExt {


### PR DESCRIPTION
Implements a more compact DSL for defining components:

```scala
case class MyComponent(initial: Int) extends ReactFnProps(MyComponent)

object MyComponent extends ReactFnComponent[MyComponent](props =>
  for
    s <- useState(props.initial)
  yield
    <.div(
      s.value,
      <.button(^.onClick --> s.modState(_ + 1), "Inc")
    )
)
```

The `useResizeDetector` demo has been migrated to this style for reference.

This is now possible since hook invocations are inside the render function.

There are also `ReactFnComponentWithChildren`, `ReactComponentForwardRef` and `ReactComponentForwardRefWithChildren` variants.

Also, fixes invocation of `useResizeDetector` monadic style without parameters.