### PR TITLE
Avoid computing unnecessary row models in tables

### DIFF
--- a/tanstack-table-demo/src/main/scala/lucuma/react/table/demo/Table1.scala
+++ b/tanstack-table-demo/src/main/scala/lucuma/react/table/demo/Table1.scala
@@ -118,6 +118,7 @@ object Table1:
                      rows,
                      enableSorting = true,
                      enableColumnResizing = true,
+                     enableFilters = true,
                      initialState =
                        TableState(sorting = Sorting(ColumnId("model") -> SortDirection.Descending))
                    )

--- a/tanstack-table/src/main/scala/lucuma/react/table/package.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/package.scala
@@ -54,6 +54,9 @@ package object table extends HooksApiExt:
     private[table] def applyOrNull[A](a: Option[A], f: (B, A) => B, fNull: B => B): B =
       a.fold(fNull(b))(a => f(b, a))
 
+    private[table] def applyWhen[A](cond: Boolean, f: B => B): B =
+      if cond then f(b) else b
+
   extension [A](opt: Null | A)
     private[table] def nullToOption: Option[A] = opt match
       case null => None


### PR DESCRIPTION
To avoid being wasteful, we should only chain the row models that are actually used by the table. See https://tanstack.com/table/v8/docs/guide/row-models.

Note that this could potentially be a breaking change in some tables, although it's very unlikely. Eg: Sorting would be disabled in tables where we didn't set ANY of the sorting properties.