### PR TITLE
Convenience dnd hook to track elements

### DIFF
--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DragAndDropScope.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DragAndDropScope.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.pragmaticdnd
+
+import japgolly.scalajs.react.feature.Context
+import lucuma.react.pragmaticdnd.facade.DropTargetRecord
+
+final case class DragAndDropScope[S, T](
+  context:  Context.Provided[DragAndDropContext],
+  dragging: Option[Data[S]],
+  dragOver: List[DropTargetRecord[T]]
+)

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/Data.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/Data.scala
@@ -15,6 +15,9 @@ object Data:
     p.value = value
     p
 
+  def unapply[D](data: Data[D]): Option[D] =
+    Some(data.value)
+
   given [D]: Conversion[D, Data[D]] with
     def apply(d: D): Data[D] = Data(d)
 

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/MonitorArgs.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/MonitorArgs.scala
@@ -29,7 +29,7 @@ object MonitorArgs {
       )
       .applyOrNot(
         onDragStart,
-        (p, f) => p.onDragStart = args => { println("HELLO"); f(args).runNow() }
+        (p, f) => p.onDragStart = args => f(args).runNow()
       )
       .applyOrNot(onDrag, (p, f) => p.onDrag = args => f(args).runNow())
       .applyOrNot(onDropTargetChange, (p, f) => p.onDropTargetChange = args => f(args).runNow())

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/hooks.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/hooks.scala
@@ -256,6 +256,34 @@ def useDragAndDropContext[S, T](
                  )
   yield DragAndDropContext.ctx.provide(contextId.some)
 
+def useDragAndDropScope[S, T](
+  canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => Boolean] = js.undefined,
+  onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
+  onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
+  onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
+  onDropTargetChange:    js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
+  onDrop:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined
+): HookResult[DragAndDropScope[S, T]] =
+  for
+    dragging <- useState[Option[Data[S]]](none)
+    dragOver <- useState[List[DropTargetRecord[T]]](List.empty)
+    provider <- useDragAndDropContext[S, T](
+                  canMonitor,
+                  onGenerateDragPreview,
+                  onDragStart = payload =>
+                    dragging.setState(payload.source.data.some) >>
+                      onDragStart.toOption.foldMap(_(payload)),
+                  onDrag = payload =>
+                    dragOver.setState(payload.location.current.dropTargets.toList) >>
+                      onDrag.toOption.foldMap(_(payload)),
+                  onDropTargetChange,
+                  onDrop = payload =>
+                    dragging.setState(none) >>
+                      dragOver.setState(List.empty) >>
+                      onDrop.toOption.foldMap(_(payload))
+                )
+  yield DragAndDropScope[S, T](provider, dragging.value, dragOver.value)
+
 def useAutoScrollRef[S](
   canScroll:        js.UndefOr[ElementGetFeedbackArgs[S] => Boolean] = js.undefined,
   getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axis] = js.undefined,


### PR DESCRIPTION
Add a convenience hook to pragmatic dnd to provide in state the dragged and dragOver elements, so as not to have to do it manually everywhere.