### PR TITLE
Pragmatic-dnd facade for list-item hitbox and React drop indicator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.98"
+ThisBuild / tlBaseVersion       := "0.99"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 ThisBuild / scalacOptions ++= Seq(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "2.1.5",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "1.1.0",
         "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "2.0.15",
+        "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "3.2.15",
         "@floating-ui/react": "^0.27.8",
         "@fortawesome/fontawesome-svg-core": "^7.1.0",
         "@fortawesome/free-solid-svg-icons": "^7.1.0",
@@ -185,6 +186,56 @@
       "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": {
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/-/pragmatic-drag-and-drop-react-drop-indicator-3.2.15.tgz",
+      "integrity": "sha512-D0wyKXsZlmkXcV00IPfFsGfOLVKw6r6vAy4oHn/E0RvHlWHSXxUScXDFKkhN4EDsEEwSxv6xmMNoj3RA8JCKUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.7.0",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
+        "@atlaskit/tokens": "^13.0.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/node_modules/@atlaskit/ds-lib": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/ds-lib/-/ds-lib-7.0.0.tgz",
+      "integrity": "sha512-Uqywr6YMi6uBpD0BtbRmG8f81fteRT7NBf62J8zzWPSs7u3Jq9G3Oruwm3y+57Dxv6IqfRwrS10WJARlCJdBLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/node_modules/@atlaskit/tokens": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-13.0.3.tgz",
+      "integrity": "sha512-7HF6IbASBf3yMyfOJcSCiVywKbWqkRNHh80UspMi07tL1lhd9mDmMZbCvvECGJ1R9g2dsmdEpkZK8zt/GWLDZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/ds-lib": "^7.0.0",
+        "@atlaskit/platform-feature-flags": "^1.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.20.0",
+        "bind-event-listener": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@atlaskit/tokens": {
@@ -498,6 +549,26 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@compiled/react": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@compiled/react/-/react-0.20.0.tgz",
+      "integrity": "sha512-mEJuYGFxIDST1H7CpksyE6a3HRVRQmeDal26O+bCHTEZlPp7iKvs5KD1FOmd2palng+S60dPFFG+UuoZDRILwA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "csstype": "^3.2.3"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/@compiled/react/node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "2.1.5",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "1.1.0",
     "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "2.0.15",
+    "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "3.2.15",
     "@floating-ui/react": "^0.27.8",
     "@fortawesome/fontawesome-svg-core": "^7.1.0",
     "@fortawesome/free-solid-svg-icons": "^7.1.0",

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/exports.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/exports.scala
@@ -3,4 +3,5 @@
 
 package lucuma.react.pragmaticdnd
 
-export facade.Data, facade.Edge, facade.Axis, facade.PublicConfig
+export facade.Data, facade.Edge, facade.Axis, facade.Axes, facade.PublicConfig, facade.Instruction,
+  facade.Operation, facade.Operations

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/exports.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/exports.scala
@@ -4,4 +4,4 @@
 package lucuma.react.pragmaticdnd
 
 export facade.Data, facade.Edge, facade.Axis, facade.Axes, facade.PublicConfig, facade.Instruction,
-  facade.Operation, facade.Operations
+  facade.Operation, facade.Operations, facade.ListItemDropIndicator, facade.LineType, facade.CssSize

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/extensions.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/extensions.scala
@@ -67,7 +67,7 @@ extension [D](data: Data[D])
     attachClosestEdge(args.element, args.input, allowedEdges)
 
   def extractClosestEdge: Option[Edge] =
-    ClosestEdgeRaw.extractClosestEdge(data).toOption
+    Option(ClosestEdgeRaw.extractClosestEdge(data))
 
   def attachInstruction(
     operations: Operations,
@@ -92,7 +92,7 @@ extension [D](data: Data[D])
     attachInstruction(operations, args.element, args.input, axis)
 
   def extractInstruction: Option[Instruction] =
-    ListItemRaw.extractInstruction(data).toOption
+    Option(ListItemRaw.extractInstruction(data))
 
 extension (axis: Axes)
   def edges: List[Edge] =

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/extensions.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/extensions.scala
@@ -69,9 +69,34 @@ extension [D](data: Data[D])
   def extractClosestEdge: Option[Edge] =
     ClosestEdgeRaw.extractClosestEdge(data).toOption
 
-extension (axis: Axis)
+  def attachInstruction(
+    operations: Operations,
+    element:    Element,
+    input:      Input,
+    axis:       Axis
+  ): Data[D] =
+    ListItemRaw.attachInstruction(data, AttachInstructionArgs(operations, element, input, axis))
+
+  def attachInstruction(
+    operations: Operations,
+    element:    Element,
+    input:      Input
+  ): Data[D] =
+    attachInstruction(operations, element, input, Axis.Vertical)
+
+  def attachInstruction[S](
+    args:       DropTargetGetFeedbackArgs[S],
+    operations: Operations,
+    axis:       Axis = Axis.Vertical
+  ): Data[D] =
+    attachInstruction(operations, args.element, args.input, axis)
+
+  def extractInstruction: Option[Instruction] =
+    ListItemRaw.extractInstruction(data).toOption
+
+extension (axis: Axes)
   def edges: List[Edge] =
     axis match
-      case Axis.Vertical   => List(Edge.Top, Edge.Bottom)
-      case Axis.Horizontal => List(Edge.Left, Edge.Right)
-      case Axis.All        => List(Edge.Top, Edge.Bottom, Edge.Left, Edge.Right)
+      case Axes.Vertical   => List(Edge.Top, Edge.Bottom)
+      case Axes.Horizontal => List(Edge.Left, Edge.Right)
+      case Axes.All        => List(Edge.Top, Edge.Bottom, Edge.Left, Edge.Right)

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/autoScroll.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/autoScroll.scala
@@ -23,11 +23,11 @@ trait WindowGetFeedbackArgs[S] extends js.Object:
   var input: Input
   var source: ElementDragPayload[S]
 
-opaque type Axis = String
-object Axis:
-  val Vertical: Axis   = "vertical"
-  val Horizontal: Axis = "horizontal"
-  val All: Axis        = "all"
+opaque type Axes = String
+object Axes:
+  val Vertical: Axes   = "vertical"
+  val Horizontal: Axes = "horizontal"
+  val All: Axes        = "all"
 
 opaque type ScrollSpeed = String
 object ScrollSpeed:
@@ -48,14 +48,14 @@ object PublicConfig:
 trait ElementAutoScrollArgs[S] extends js.Object:
   var element: HTMLElement
   var canScroll: js.UndefOr[js.Function1[ElementGetFeedbackArgs[S], Boolean]]
-  var getAllowedAxis: js.UndefOr[js.Function1[ElementGetFeedbackArgs[S], Axis]]
+  var getAllowedAxis: js.UndefOr[js.Function1[ElementGetFeedbackArgs[S], Axes]]
   var getConfiguration: js.UndefOr[js.Function1[ElementGetFeedbackArgs[S], PublicConfig]]
 
 object ElementAutoScrollArgs:
   def apply[S](
     element:          HTMLElement,
     canScroll:        js.UndefOr[ElementGetFeedbackArgs[S] => Boolean] = js.undefined,
-    getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axis] = js.undefined,
+    getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axes] = js.undefined,
     getConfiguration: js.UndefOr[ElementGetFeedbackArgs[S] => PublicConfig] = js.undefined
   ): ElementAutoScrollArgs[S] =
     val p = (new js.Object).asInstanceOf[ElementAutoScrollArgs[S]]
@@ -68,13 +68,13 @@ object ElementAutoScrollArgs:
 @js.native
 trait WindowAutoScrollArgs[S] extends js.Object:
   var canScroll: js.UndefOr[js.Function1[WindowGetFeedbackArgs[S], Boolean]]
-  var getAllowedAxis: js.UndefOr[js.Function1[WindowGetFeedbackArgs[S], Axis]]
+  var getAllowedAxis: js.UndefOr[js.Function1[WindowGetFeedbackArgs[S], Axes]]
   var getConfiguration: js.UndefOr[js.Function1[WindowGetFeedbackArgs[S], PublicConfig]]
 
 object WindowAutoScrollArgs:
   def apply[S](
     canScroll:        js.UndefOr[WindowGetFeedbackArgs[S] => Boolean] = js.undefined,
-    getAllowedAxis:   js.UndefOr[WindowGetFeedbackArgs[S] => Axis] = js.undefined,
+    getAllowedAxis:   js.UndefOr[WindowGetFeedbackArgs[S] => Axes] = js.undefined,
     getConfiguration: js.UndefOr[WindowGetFeedbackArgs[S] => PublicConfig] = js.undefined
   ): WindowAutoScrollArgs[S] =
     val p = (new js.Object).asInstanceOf[WindowAutoScrollArgs[S]]
@@ -93,7 +93,7 @@ object AutoScroll:
   def forElement[S](
     element:          HTMLElement,
     canScroll:        js.UndefOr[ElementGetFeedbackArgs[S] => Boolean] = js.undefined,
-    getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axis] = js.undefined,
+    getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axes] = js.undefined,
     getConfiguration: js.UndefOr[ElementGetFeedbackArgs[S] => PublicConfig] = js.undefined
   ): CallbackTo[Callback] =
     CallbackTo:
@@ -103,7 +103,7 @@ object AutoScroll:
 
   def forWindow[S](
     canScroll:        js.UndefOr[WindowGetFeedbackArgs[S] => Boolean] = js.undefined,
-    getAllowedAxis:   js.UndefOr[WindowGetFeedbackArgs[S] => Axis] = js.undefined,
+    getAllowedAxis:   js.UndefOr[WindowGetFeedbackArgs[S] => Axes] = js.undefined,
     getConfiguration: js.UndefOr[WindowGetFeedbackArgs[S] => PublicConfig] = js.undefined
   ): CallbackTo[Callback] =
     CallbackTo:

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/hitbox.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/hitbox.scala
@@ -41,7 +41,7 @@ object ClosestEdgeRaw extends js.Object:
     args: AttachClosestEdgeArgs
   ): Data[T] = js.native
 
-  def extractClosestEdge[T](data: Data[T]): js.UndefOr[Edge] = js.native
+  def extractClosestEdge[T](data: Data[T]): Edge | Null = js.native
 
 opaque type Operation = String
 object Operation:
@@ -89,10 +89,11 @@ object Operations:
   def available(operations: Operation*): Operations =
     operations.map(_ -> Availability.Available).toMap
 
-  val Reorder: Operations = available(Operation.ReorderBefore, Operation.ReorderAfter)
-  val Combine: Operations = available(Operation.Combine)
-  val All: Operations     =
+  val Reorder: Operations                = available(Operation.ReorderBefore, Operation.ReorderAfter)
+  val Combine: Operations                = available(Operation.Combine)
+  val All: Operations                    =
     available(Operation.ReorderBefore, Operation.ReorderAfter, Operation.Combine)
+  val ReorderOnExpandedGroup: Operations = available(Operation.ReorderBefore, Operation.Combine)
 
 object AttachInstructionArgs:
   def apply(
@@ -116,4 +117,4 @@ object ListItemRaw extends js.Object:
     args: AttachInstructionArgs
   ): Data[T] = js.native
 
-  def extractInstruction[T](data: Data[T]): js.UndefOr[Instruction] = js.native
+  def extractInstruction[T](data: Data[T]): Instruction | Null = js.native

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/hitbox.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/hitbox.scala
@@ -42,3 +42,78 @@ object ClosestEdgeRaw extends js.Object:
   ): Data[T] = js.native
 
   def extractClosestEdge[T](data: Data[T]): js.UndefOr[Edge] = js.native
+
+opaque type Operation = String
+object Operation:
+  val ReorderBefore: Operation = "reorder-before"
+  val ReorderAfter: Operation  = "reorder-after"
+  val Combine: Operation       = "combine"
+
+opaque type Availability = String
+object Availability:
+  val Available: Availability    = "available"
+  val NotAvailable: Availability = "not-available"
+  val Blocked: Availability      = "blocked"
+
+opaque type Axis = String
+object Axis:
+  val Vertical: Axis   = "vertical"
+  val Horizontal: Axis = "horizontal"
+
+@js.native
+trait Instruction extends js.Object:
+  val operation: Operation = js.native
+  val blocked: Boolean     = js.native
+  val axis: Axis           = js.native
+
+@js.native
+trait AttachInstructionArgs extends js.Object:
+  var operations: js.Dictionary[Availability]
+  var element: Element
+  var input: Input
+  var axis: Axis
+
+opaque type Operations = Map[Operation, Availability]
+object Operations:
+  def apply(
+    reorderBefore: Availability = Availability.NotAvailable,
+    reorderAfter:  Availability = Availability.NotAvailable,
+    combine:       Availability = Availability.NotAvailable
+  ): Operations =
+    Map(
+      Operation.ReorderBefore -> reorderBefore,
+      Operation.ReorderAfter  -> reorderAfter,
+      Operation.Combine       -> combine
+    )
+
+  def available(operations: Operation*): Operations =
+    operations.map(_ -> Availability.Available).toMap
+
+  val Reorder: Operations = available(Operation.ReorderBefore, Operation.ReorderAfter)
+  val Combine: Operations = available(Operation.Combine)
+  val All: Operations     =
+    available(Operation.ReorderBefore, Operation.ReorderAfter, Operation.Combine)
+
+object AttachInstructionArgs:
+  def apply(
+    operations: Operations,
+    element:    Element,
+    input:      Input,
+    axis:       Axis = Axis.Vertical
+  ): AttachInstructionArgs =
+    val p = (new js.Object).asInstanceOf[AttachInstructionArgs]
+    p.operations = operations.asInstanceOf[Map[String, Availability]].toJSDictionary
+    p.element = element
+    p.input = input
+    p.axis = axis
+    p
+
+@js.native
+@JSImport("@atlaskit/pragmatic-drag-and-drop-hitbox/list-item", JSImport.Namespace)
+object ListItemRaw extends js.Object:
+  def attachInstruction[T](
+    data: Data[T],
+    args: AttachInstructionArgs
+  ): Data[T] = js.native
+
+  def extractInstruction[T](data: Data[T]): js.UndefOr[Instruction] = js.native

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/reactDropIndicator.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/reactDropIndicator.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.pragmaticdnd.facade
+
+import japgolly.scalajs.react.*
+import lucuma.react.common.*
+
+import scalajs.js
+import scalajs.js.annotation.JSImport
+
+opaque type CssSize = String
+object CssSize:
+  def apply(value: String): CssSize           = value
+  extension (s:    CssSize) def value: String = s
+  // For some reason, we seem to need this. The compiler won't convert automatically at call sites.
+  given Conversion[CssSize, js.UndefOr[CssSize]] with
+    def apply(s: CssSize): js.UndefOr[CssSize] = s
+
+opaque type LineType = String
+object LineType:
+  val Terminal: LineType        = "terminal"
+  val NoTerminal: LineType      = "no-terminal"
+  val TerminalNoBleed: LineType = "terminal-no-bleed"
+
+final case class ListItemDropIndicator(
+  instruction: Instruction,
+  lineGap:     js.UndefOr[CssSize] = js.undefined,
+  lineType:    js.UndefOr[LineType] = js.undefined
+) extends GenericFnComponentP[ListItemDropIndicator.Props]:
+  override protected def cprops = ListItemDropIndicator.props(this)
+  override def render           = ListItemDropIndicator.component(cprops)
+
+object ListItemDropIndicator:
+  @js.native
+  @JSImport("@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/list-item", "DropIndicator")
+  object RawDropIndicator extends js.Object
+
+  @js.native
+  trait Props extends js.Object:
+    var instruction: Instruction
+    var lineGap: js.UndefOr[CssSize]
+    var lineType: js.UndefOr[LineType]
+
+  private def props(p: ListItemDropIndicator): Props =
+    val r = (new js.Object).asInstanceOf[Props]
+    r.instruction = p.instruction
+    p.lineGap.foreach(v => r.lineGap = v)
+    p.lineType.foreach(v => r.lineType = v)
+    r
+
+  val component = JsFnComponent[Props, Children.None](RawDropIndicator)

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/hooks.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/hooks.scala
@@ -286,7 +286,7 @@ def useDragAndDropScope[S, T](
 
 def useAutoScrollRef[S](
   canScroll:        js.UndefOr[ElementGetFeedbackArgs[S] => Boolean] = js.undefined,
-  getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axis] = js.undefined,
+  getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axes] = js.undefined,
   getConfiguration: js.UndefOr[ElementGetFeedbackArgs[S] => PublicConfig] = js.undefined,
   containerRef:     js.UndefOr[Ref.ToVdom[HTMLElement]] = js.undefined
 ): HookResult[Ref.ToVdom[HTMLElement]] =


### PR DESCRIPTION
Pragmatic-dnd includes utilities to track if we are dragging before, after, or within an item. Also, for rendering the drop position.

Here's the facade, so we can use this to better indicate drop position on trees.