### PR TITLE
Allow callbacks in drag-and-drop functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.99"
+ThisBuild / tlBaseVersion       := "0.100"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 ThisBuild / scalacOptions ++= Seq(

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/Draggable.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/Draggable.scala
@@ -13,8 +13,9 @@ import scalajs.js
 
 final case class Draggable[S, T](
   tag:                   TagOf[HTMLElement],
-  canDrag:               js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-  getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
+  canDrag:               js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Boolean]] = js.undefined,
+  getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DraggableDropTarget.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DraggableDropTarget.scala
@@ -13,11 +13,13 @@ import scalajs.js
 
 final case class DraggableDropTarget[S, T](
   tag:                             TagOf[HTMLElement],
-  canDrag:                         js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-  canDrop:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
-  getInitialData:                  js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
-  getData:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => Data[T]] = js.undefined,
-  getIsSticky:                     js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
+  canDrag:                         js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Boolean]] = js.undefined,
+  canDrop:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+  getInitialData:                  js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+    js.undefined,
+  getData:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Data[T]]] = js.undefined,
+  getIsSticky:                     js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onDraggableGenerateDragPreview:  js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDraggableDragStart:            js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDraggableDrag:                 js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DraggableDropTargetWithHandle.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DraggableDropTargetWithHandle.scala
@@ -14,10 +14,12 @@ import scalajs.js
 final case class DraggableDropTargetWithHandle[S, T](
   tag:                             Ref.ToVdom[HTMLElement] => TagOf[HTMLElement],
   canDrag:                         js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-  canDrop:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
-  getInitialData:                  js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
-  getData:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => Data[T]] = js.undefined,
-  getIsSticky:                     js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
+  canDrop:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+  getInitialData:                  js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+    js.undefined,
+  getData:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Data[T]]] = js.undefined,
+  getIsSticky:                     js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onDraggableGenerateDragPreview:  js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDraggableDragStart:            js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDraggableDrag:                 js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DraggableWithHandle.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DraggableWithHandle.scala
@@ -13,8 +13,9 @@ import scalajs.js
 
 final case class DraggableWithHandle[S, T](
   tag:                   Ref.ToVdom[HTMLElement] => TagOf[HTMLElement],
-  canDrag:               js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-  getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
+  canDrag:               js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Boolean]] = js.undefined,
+  getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DropTarget.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/DropTarget.scala
@@ -13,9 +13,10 @@ import scalajs.js
 
 final case class DropTarget[S, T](
   tag:                   TagOf[HTMLElement],
-  getData:               js.UndefOr[DropTargetGetFeedbackArgs[S] => Data[T]] = js.undefined,
-  canDrop:               js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
-  getIsSticky:           js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
+  getData:               js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Data[T]]] = js.undefined,
+  canDrop:               js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+  getIsSticky:           js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/ElementAdapter.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/ElementAdapter.scala
@@ -13,8 +13,9 @@ object ElementAdapter:
   def draggable[S, T](
     element:               HTMLElement,
     dragHandle:            js.UndefOr[HTMLElement] = js.undefined,
-    canDrag:               js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-    getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
+    canDrag:               js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Boolean]] = js.undefined,
+    getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+      js.undefined,
     onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
     onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
     onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -27,8 +28,8 @@ object ElementAdapter:
           DraggableArgs[S, T](
             element,
             dragHandle,
-            canDrag,
-            getInitialData,
+            canDrag.resolve,
+            getInitialData.resolve,
             onGenerateDragPreview,
             onDragStart,
             onDrag,
@@ -39,9 +40,10 @@ object ElementAdapter:
 
   def dropTarget[S, T](
     element:               HTMLElement,
-    getData:               js.UndefOr[DropTargetGetFeedbackArgs[S] => Data[T]] = js.undefined,
-    canDrop:               js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
-    getIsSticky:           js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
+    getData:               js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Data[T]]] = js.undefined,
+    canDrop:               js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+    getIsSticky:           js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] =
+      js.undefined,
     onGenerateDragPreview: js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,
     onDragStart:           js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,
     onDrag:                js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,
@@ -55,9 +57,9 @@ object ElementAdapter:
         ElementAdapterRaw.dropTargetForElements:
           DropTargetArgs[S, T](
             element,
-            getData,
-            canDrop,
-            getIsSticky,
+            getData.resolve,
+            canDrop.resolve,
+            getIsSticky.resolve,
             onGenerateDragPreview,
             onDragStart,
             onDrag,
@@ -68,7 +70,8 @@ object ElementAdapter:
           )
 
   def monitor[S, T](
-    canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => Boolean] = js.undefined,
+    canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => OptionalCallbackTo[Boolean]] =
+      js.undefined,
     onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
     onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
     onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -79,7 +82,7 @@ object ElementAdapter:
       Callback.fromJsFn:
         ElementAdapterRaw.monitorForElements:
           MonitorArgs[S, T](
-            canMonitor,
+            canMonitor.resolve,
             onGenerateDragPreview,
             onDragStart,
             onDrag,

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/aliases.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/aliases.scala
@@ -11,16 +11,16 @@ import scala.scalajs.js
 type OptionalCallbackTo[A] = A | CallbackTo[A]
 
 extension [A](x: OptionalCallbackTo[A])
-  def resolve: A =
+  private[pragmaticdnd] def resolve: A =
     x match
       case cb: CallbackTo[?] => cb.asInstanceOf[CallbackTo[A]].runNow()
       case a                 => a.asInstanceOf[A]
 
 extension [A, B](f: B => OptionalCallbackTo[A])
-  def resolve: B => A =
+  private[pragmaticdnd] def resolve: B => A =
     b => f(b).resolve
 
 extension [A, B](f: js.UndefOr[B => OptionalCallbackTo[A]])
   @targetName("resolveFnInUndef")
-  def resolve: js.UndefOr[B => A] =
+  private[pragmaticdnd] def resolve: js.UndefOr[B => A] =
     f.map(_.resolve)

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/aliases.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/aliases.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.react.pragmaticdnd
+
+import japgolly.scalajs.react.callback.CallbackTo
+
+import scala.annotation.targetName
+import scala.scalajs.js
+
+type OptionalCallbackTo[A] = A | CallbackTo[A]
+
+extension [A](x: OptionalCallbackTo[A])
+  def resolve: A =
+    x match
+      case cb: CallbackTo[?] => cb.asInstanceOf[CallbackTo[A]].runNow()
+      case a                 => a.asInstanceOf[A]
+
+extension [A, B](f: B => OptionalCallbackTo[A])
+  def resolve: B => A =
+    b => f(b).resolve
+
+extension [A, B](f: js.UndefOr[B => OptionalCallbackTo[A]])
+  @targetName("resolveFnInUndef")
+  def resolve: js.UndefOr[B => A] =
+    f.map(_.resolve)

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/autoScroll.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/facade/autoScroll.scala
@@ -5,8 +5,10 @@ package lucuma.react.pragmaticdnd.facade
 
 import japgolly.scalajs.react.callback.Callback
 import japgolly.scalajs.react.callback.CallbackTo
+import lucuma.react.pragmaticdnd.OptionalCallbackTo
 import lucuma.react.pragmaticdnd.facade.ElementDragPayload
 import lucuma.react.pragmaticdnd.facade.Input
+import lucuma.react.pragmaticdnd.resolve
 import org.scalajs.dom.HTMLElement
 
 import scalajs.js
@@ -92,14 +94,21 @@ object AutoScrollRaw extends js.Object:
 object AutoScroll:
   def forElement[S](
     element:          HTMLElement,
-    canScroll:        js.UndefOr[ElementGetFeedbackArgs[S] => Boolean] = js.undefined,
-    getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axes] = js.undefined,
-    getConfiguration: js.UndefOr[ElementGetFeedbackArgs[S] => PublicConfig] = js.undefined
+    canScroll:        js.UndefOr[ElementGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+    getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => OptionalCallbackTo[Axes]] =
+      js.undefined,
+    getConfiguration: js.UndefOr[ElementGetFeedbackArgs[S] => OptionalCallbackTo[PublicConfig]] =
+      js.undefined
   ): CallbackTo[Callback] =
     CallbackTo:
       Callback.fromJsFn:
         AutoScrollRaw.autoScrollForElements:
-          ElementAutoScrollArgs(element, canScroll, getAllowedAxis, getConfiguration)
+          ElementAutoScrollArgs(
+            element,
+            canScroll.resolve,
+            getAllowedAxis.resolve,
+            getConfiguration.resolve
+          )
 
   def forWindow[S](
     canScroll:        js.UndefOr[WindowGetFeedbackArgs[S] => Boolean] = js.undefined,

--- a/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/hooks.scala
+++ b/pragmatic-dnd/src/main/scala/lucuma/react/pragmaticdnd/hooks.scala
@@ -13,8 +13,9 @@ import org.scalajs.dom.HTMLElement
 import scalajs.js
 
 def useDraggableWithHandleRefs[S, T](
-  canDrag:               js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-  getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
+  canDrag:               js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Boolean]] = js.undefined,
+  getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -32,7 +33,7 @@ def useDraggableWithHandleRefs[S, T](
                          elem,
                          handleElem,
                          canDrag,
-                         contextualizeGetInitialData(context)(getInitialData),
+                         contextualizeGetInitialData(context)(getInitialData.resolve),
                          onGenerateDragPreview,
                          onDragStart,
                          onDrag,
@@ -42,8 +43,9 @@ def useDraggableWithHandleRefs[S, T](
   yield (ref, handleRef)
 
 def useDraggableRef[S, T](
-  canDrag:               js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-  getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
+  canDrag:               js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Boolean]] = js.undefined,
+  getInitialData:        js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -60,7 +62,7 @@ def useDraggableRef[S, T](
                        elem,
                        js.undefined,
                        canDrag,
-                       contextualizeGetInitialData(context)(getInitialData),
+                       contextualizeGetInitialData(context)(getInitialData.resolve),
                        onGenerateDragPreview,
                        onDragStart,
                        onDrag,
@@ -70,9 +72,10 @@ def useDraggableRef[S, T](
   yield ref
 
 def useDropTargetRef[S, T](
-  getData:               js.UndefOr[DropTargetGetFeedbackArgs[S] => Data[T]] = js.undefined,
-  canDrop:               js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
-  getIsSticky:           js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
+  getData:               js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Data[T]]] = js.undefined,
+  canDrop:               js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+  getIsSticky:           js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[DropTargetEventPayload[S, T] => Callback] = js.undefined,
@@ -89,8 +92,8 @@ def useDropTargetRef[S, T](
                    refValue.foldMap: elem =>
                      ElementAdapter.dropTarget[S, T](
                        elem,
-                       contextualizeGetData(context)(getData),
-                       decontextualizeCanDrop(context)(canDrop),
+                       contextualizeGetData(context)(getData.resolve),
+                       decontextualizeCanDrop(context)(canDrop.resolve),
                        getIsSticky,
                        onGenerateDragPreview,
                        onDragStart,
@@ -104,11 +107,13 @@ def useDropTargetRef[S, T](
 
 // Combined Draggable + Drop Target
 def useDraggableDropTargetWithHandleRefs[S, T](
-  canDrag:                         js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-  canDrop:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
-  getInitialData:                  js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
-  getData:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => Data[T]] = js.undefined,
-  getIsSticky:                     js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
+  canDrag:                         js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Boolean]] = js.undefined,
+  canDrop:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+  getInitialData:                  js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+    js.undefined,
+  getData:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Data[T]]] = js.undefined,
+  getIsSticky:                     js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onDraggableGenerateDragPreview:  js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDraggableDragStart:            js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDraggableDrag:                 js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -135,7 +140,7 @@ def useDraggableDropTargetWithHandleRefs[S, T](
                              elem,
                              handleElem,
                              canDrag,
-                             contextualizeGetInitialData(context)(getInitialData),
+                             contextualizeGetInitialData(context)(getInitialData.resolve),
                              onDraggableGenerateDragPreview,
                              onDraggableDragStart,
                              onDraggableDrag,
@@ -145,8 +150,8 @@ def useDraggableDropTargetWithHandleRefs[S, T](
                          dropTargetCleanup <-
                            ElementAdapter.dropTarget[S, T](
                              elem,
-                             contextualizeGetData(context)(getData),
-                             decontextualizeCanDrop(context)(canDrop),
+                             contextualizeGetData(context)(getData.resolve),
+                             decontextualizeCanDrop(context)(canDrop.resolve),
                              getIsSticky,
                              onDropTargetGenerateDragPreview,
                              onDropTargetDragStart,
@@ -160,11 +165,13 @@ def useDraggableDropTargetWithHandleRefs[S, T](
   yield (ref, handleRef)
 
 def useDraggableDropTargetRef[S, T](
-  canDrag:                         js.UndefOr[DraggableGetFeedbackArgs => Boolean] = js.undefined,
-  canDrop:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
-  getInitialData:                  js.UndefOr[DraggableGetFeedbackArgs => Data[S]] = js.undefined,
-  getData:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => Data[T]] = js.undefined,
-  getIsSticky:                     js.UndefOr[DropTargetGetFeedbackArgs[S] => Boolean] = js.undefined,
+  canDrag:                         js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Boolean]] = js.undefined,
+  canDrop:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+  getInitialData:                  js.UndefOr[DraggableGetFeedbackArgs => OptionalCallbackTo[Data[S]]] =
+    js.undefined,
+  getData:                         js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Data[T]]] = js.undefined,
+  getIsSticky:                     js.UndefOr[DropTargetGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onDraggableGenerateDragPreview:  js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDraggableDragStart:            js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDraggableDrag:                 js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -190,7 +197,7 @@ def useDraggableDropTargetRef[S, T](
                            elem,
                            js.undefined,
                            canDrag,
-                           contextualizeGetInitialData(context)(getInitialData),
+                           contextualizeGetInitialData(context)(getInitialData.resolve),
                            onDraggableGenerateDragPreview,
                            onDraggableDragStart,
                            onDraggableDrag,
@@ -200,8 +207,8 @@ def useDraggableDropTargetRef[S, T](
                        dropTargetCleanup <-
                          ElementAdapter.dropTarget[S, T](
                            elem,
-                           contextualizeGetData(context)(getData),
-                           decontextualizeCanDrop(context)(canDrop),
+                           contextualizeGetData(context)(getData.resolve),
+                           decontextualizeCanDrop(context)(canDrop.resolve),
                            getIsSticky,
                            onDropTargetGenerateDragPreview,
                            onDropTargetDragStart,
@@ -219,7 +226,8 @@ def useDraggableDropTargetRef[S, T](
  * `useDragAndDropContext` instead.
  */
 def useDragAndDropMonitor[S, T](
-  canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => Boolean] = js.undefined,
+  canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -237,7 +245,8 @@ def useDragAndDropMonitor[S, T](
     )
 
 def useDragAndDropContext[S, T](
-  canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => Boolean] = js.undefined,
+  canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -247,7 +256,7 @@ def useDragAndDropContext[S, T](
   for
     contextId <- useId
     _         <- useDragAndDropMonitor[S, T](
-                   decontextualizeCanMonitor(contextId.some)(canMonitor),
+                   decontextualizeCanMonitor(contextId.some)(canMonitor.resolve),
                    onGenerateDragPreview,
                    onDragStart,
                    onDrag,
@@ -257,7 +266,8 @@ def useDragAndDropContext[S, T](
   yield DragAndDropContext.ctx.provide(contextId.some)
 
 def useDragAndDropScope[S, T](
-  canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => Boolean] = js.undefined,
+  canMonitor:            js.UndefOr[MonitorGetFeedbackArgs[S, T] => OptionalCallbackTo[Boolean]] =
+    js.undefined,
   onGenerateDragPreview: js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDragStart:           js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
   onDrag:                js.UndefOr[BaseEventPayload[S, T] => Callback] = js.undefined,
@@ -285,9 +295,10 @@ def useDragAndDropScope[S, T](
   yield DragAndDropScope[S, T](provider, dragging.value, dragOver.value)
 
 def useAutoScrollRef[S](
-  canScroll:        js.UndefOr[ElementGetFeedbackArgs[S] => Boolean] = js.undefined,
-  getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => Axes] = js.undefined,
-  getConfiguration: js.UndefOr[ElementGetFeedbackArgs[S] => PublicConfig] = js.undefined,
+  canScroll:        js.UndefOr[ElementGetFeedbackArgs[S] => OptionalCallbackTo[Boolean]] = js.undefined,
+  getAllowedAxis:   js.UndefOr[ElementGetFeedbackArgs[S] => OptionalCallbackTo[Axes]] = js.undefined,
+  getConfiguration: js.UndefOr[ElementGetFeedbackArgs[S] => OptionalCallbackTo[PublicConfig]] =
+    js.undefined,
   containerRef:     js.UndefOr[Ref.ToVdom[HTMLElement]] = js.undefined
 ): HookResult[Ref.ToVdom[HTMLElement]] =
   for


### PR DESCRIPTION
Support keep passing values directly so as not to hurt ergonomics in the majority of cases, but also support `CallbackTo` for the few cases where we need them.