### PR TITLE
Fix floating-ui tooltip loop bug via stable reference

### DIFF
--- a/floatingui/src/main/scala/lucuma/react/floatingui/Tooltip.scala
+++ b/floatingui/src/main/scala/lucuma/react/floatingui/Tooltip.scala
@@ -5,13 +5,12 @@ package lucuma.react.floatingui
 
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.feature.ReactFragment
+import japgolly.scalajs.react.vdom.TagMod
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.ReactFnProps
 import lucuma.react.common.Style
 import lucuma.react.floatingui.hooks.*
 import org.scalajs.dom
-
-import scala.scalajs.js
 
 /**
  * Tooltip base on floating ui see: https://floating-ui.com/docs/react-dom
@@ -47,7 +46,7 @@ object Tooltip {
       .useInteractionsBy { (_, _, _, h) =>
         List(middleware.useHover(h.context))
       }
-      .render { (props, open, arrow, floating, _) =>
+      .render { (props, open, arrow, floating, interactions) =>
         val display: Map[String, String | Int] =
           if (open.value) Map.empty[String, String | Int]
           else Map[String, String | Int]("display" -> "none")
@@ -114,10 +113,15 @@ object Tooltip {
         val arrowStyle =
           arrowOpt.fold(Style(display))(_ => Style(display ++ arrowStyleMap ++ placementStyle))
         ReactFragment(
-          props.trigger(^.untypedRef(floating.refs.setReference)),
+          // Both the stable ref and the interaction props are required: see `Interactions`.
+          props.trigger(
+            Interactions.stableRef(floating.refs.setReference),
+            TagMod.fn(_.addAttrsObject(interactions.getReferenceProps()))
+          ),
           if (open.value)
             <.div(
-              ^.untypedRef(floating.refs.setFloating),
+              Interactions.stableRef(floating.refs.setFloating),
+              TagMod.fn(_.addAttrsObject(interactions.getFloatingProps())),
               ^.cls   := "tooltip",
               ^.style := style.toJsObject,
               props.tooltip,

--- a/floatingui/src/main/scala/lucuma/react/floatingui/hooks.scala
+++ b/floatingui/src/main/scala/lucuma/react/floatingui/hooks.scala
@@ -20,10 +20,10 @@ object HooksApiExt {
   private val floatingHook: CustomHook[UseFloatingProps, UseFloatingReturn] =
     CustomHook.fromHookResult(useFloating(_))
 
-  val useInteractions: ElementPropsList => HookResult[UseFloatingReturn] =
+  val useInteractions: ElementPropsList => HookResult[UseInteractionsReturn] =
     HookResult.fromFunction(use.useInteractions(_)).contramap(_.toJSArray)
 
-  private val interactionsHook: CustomHook[ElementPropsList, UseFloatingReturn] =
+  private val interactionsHook: CustomHook[ElementPropsList, UseInteractionsReturn] =
     CustomHook.fromHookResult(useInteractions(_))
 
   sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
@@ -40,12 +40,12 @@ object HooksApiExt {
 
     final def useInteractions(pos: ElementPropsList)(implicit
       step: Step
-    ): step.Next[UseFloatingReturn] =
+    ): step.Next[UseInteractionsReturn] =
       useInteractionsBy(_ => pos)
 
     final def useInteractionsBy(pos: Ctx => ElementPropsList)(implicit
       step: Step
-    ): step.Next[UseFloatingReturn] =
+    ): step.Next[UseInteractionsReturn] =
       api.customBy(ctx => interactionsHook(pos(ctx)))
   }
 
@@ -60,7 +60,7 @@ object HooksApiExt {
 
     def useInteractionsBy(pos: CtxFn[ElementPropsList])(implicit
       step: Step
-    ): step.Next[UseFloatingReturn] =
+    ): step.Next[UseInteractionsReturn] =
       useInteractionsBy(step.squash(pos)(_))
 
   }

--- a/floatingui/src/main/scala/lucuma/react/floatingui/package.scala
+++ b/floatingui/src/main/scala/lucuma/react/floatingui/package.scala
@@ -5,7 +5,9 @@ package lucuma.react.floatingui
 
 import cats.syntax.all.*
 import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.TagMod
 import japgolly.scalajs.react.vdom.TopNode
+import japgolly.scalajs.react.vdom.VdomBuilder
 import lucuma.react.common.EnumValue
 import lucuma.react.common.syntax.callback.*
 import org.scalajs.dom.html
@@ -70,6 +72,25 @@ trait FloatingRefs extends js.Object {
   var setReference: js.Function1[TopNode, Unit] = js.native
   var setFloating: js.Function1[TopNode, Unit]  = js.native
 }
+
+/**
+ * Result of [[use.useInteractions]]
+ */
+@js.native
+trait UseInteractionsReturn extends js.Object {
+  def getReferenceProps(): js.Object = js.native
+  def getFloatingProps(): js.Object  = js.native
+}
+
+/** Helpers for applying floating-ui prop-getter results to scalajs-react vdom. */
+object Interactions:
+
+  /**
+   * Attach a floating-ui ref setter as a React `ref` without re-wrapping it. Unlike
+   * `^.untypedRef(fn)`, which wraps `fn` in a fresh closure every render.
+   */
+  def stableRef(fn: js.Function1[TopNode, Unit]): TagMod =
+    TagMod.fn((b: VdomBuilder) => b.addAttr("ref", fn))
 
 @js.native
 trait UseFloatingReturn extends js.Object {
@@ -243,8 +264,8 @@ object use {
   ): UseFloatingReturn                        =
     ^.asInstanceOf[js.Dynamic].applyDynamic("useFloating")(props).asInstanceOf[UseFloatingReturn]
 
-  inline def useInteractions(propsList: js.Array[ElementProps | Unit]): UseFloatingReturn =
+  inline def useInteractions(propsList: js.Array[ElementProps | Unit]): UseInteractionsReturn =
     ^.asInstanceOf[js.Dynamic]
       .applyDynamic("useInteractions")(propsList.asInstanceOf[js.Any])
-      .asInstanceOf[UseFloatingReturn]
+      .asInstanceOf[UseInteractionsReturn]
 }


### PR DESCRIPTION
We found some crashes in explore with "Maximum update depth exceeded" that traced back to `Tooltip`            
                                                                              
Tooltip attached floating-ui's refs via  `^.untypedRef(floating.refs.setReference)`. `untypedRef(fn) ` wraps `fn` in a fresh closure on every render, so React sees a new ref identity each render and can enter in a rendering loop
                                                                              
Also the facade `UseFloatingReturn` was updated to use the correct API from `floatingui`            
