### PR TITLE
Fixes to avoid a minified react error 185

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
 
-ThisBuild / tlBaseVersion       := "0.102"
+ThisBuild / tlBaseVersion       := "0.103"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowTargetBranches += "!dependabot/**"
 ThisBuild / scalacOptions ++= Seq(

--- a/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoComponents.scala
+++ b/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoComponents.scala
@@ -683,7 +683,7 @@ object DemoComponents {
               <.div(
                 DemoStyles.VerticalStack,
                 <.label("Inline Menu", DemoStyles.FormFieldLabel),
-                InlineMenu(model = menuItems)(mouseEntered("InlineMenu")),
+                InlineMenu(model = Reusable.always(menuItems))(mouseEntered("InlineMenu")),
                 <.label("Tab Menu", DemoStyles.FormFieldLabel),
                 TabMenu(
                   model = List(MenuItem.Item("Tab 1", icon = "pi pi-hourglass"),
@@ -725,7 +725,7 @@ object DemoComponents {
             ConfirmPopup(),
             ConfirmDialog(),
             PopupTieredMenu(
-              menuItems,
+              Reusable.always(menuItems),
               onShow = Callback.log("Showing PopupMenu"),
               onHide = Callback.log("Hiding PopupMenu")
             ).withMods(

--- a/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
+++ b/prime-react-demo/src/main/scala/lucuma/react/table/demo/DemoControlsPanel.scala
@@ -352,7 +352,7 @@ object DemoControlsPanel {
                 SplitButton(
                   id = "split-button1",
                   onClick = toastRef.show(MessageItem(summary = "Split button main action")),
-                  model = splitButtonMenuItems,
+                  model = Reusable.always(splitButtonMenuItems),
                   label = "Vanilla",
                   icon = "pi pi-sparkles",
                   clazz = Css("main-class"),
@@ -362,7 +362,7 @@ object DemoControlsPanel {
                 ),
                 SplitButton(
                   onClick = toastRef.show(MessageItem(summary = "Split button main action")),
-                  model = splitButtonMenuItems,
+                  model = Reusable.always(splitButtonMenuItems),
                   label = "Large Rounded",
                   icon = "pi pi-sparkles",
                   size = Button.Size.Large,
@@ -371,7 +371,7 @@ object DemoControlsPanel {
                 ),
                 SplitButton(
                   onClick = toastRef.show(MessageItem(summary = "Split button main action")),
-                  model = splitButtonMenuItems,
+                  model = Reusable.always(splitButtonMenuItems),
                   label = "Small Outlined",
                   icon = "pi pi-sparkles",
                   size = Button.Size.Small,

--- a/prime-react/src/main/scala/lucuma/react/primereact/InlineMenu.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/InlineMenu.scala
@@ -12,7 +12,7 @@ import scalajs.js
 import scalajs.js.JSConverters.*
 
 case class InlineMenu(
-  model:     List[MenuItem],
+  model:     Reusable[List[MenuItem]],
   id:        js.UndefOr[String] = js.undefined,
   clazz:     js.UndefOr[Css] = js.undefined,
   modifiers: Seq[TagMod] = Seq.empty
@@ -25,8 +25,9 @@ case class InlineMenu(
 object InlineMenu {
   private val component =
     ScalaFnComponent[InlineMenu] { props =>
-      CMenu
-        .model(props.model.map(_.asInstanceOf[Any]).toJSArray)
+      for modelArray <- useMemo(props.model)(_.value.map(_.asInstanceOf[Any]).toJSArray)
+      yield CMenu
+        .model(modelArray.value)
         .applyOrNot(props.id, _.id(_))
         .applyOrNot(props.clazz, (c, p) => c.className(p.htmlClass))(
           props.modifiers.toTagMod

--- a/prime-react/src/main/scala/lucuma/react/primereact/PopupMenu.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/PopupMenu.scala
@@ -4,15 +4,14 @@
 package lucuma.react.primereact
 
 import japgolly.scalajs.react.*
-import japgolly.scalajs.react.CtorType.Props
-import japgolly.scalajs.react.component.Js.ComponentWithFacade
+import japgolly.scalajs.react.component.Js
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.*
 import org.scalajs.dom.*
 
-import scalajs.js.annotation.JSImport
 import scalajs.js
 import scalajs.js.JSConverters.*
+import scalajs.js.annotation.JSImport
 
 case class PopupMenuRef(
   ref: Ref.ToJsComponent[
@@ -27,25 +26,31 @@ case class PopupMenuRef(
 }
 
 case class PopupMenu(
-  model:      Seq[MenuItem],
-  id:         js.UndefOr[String] = js.undefined,
-  clazz:      js.UndefOr[Css] = js.undefined,
-  baseZIndex: js.UndefOr[Int] = js.undefined,                        // default: 0
-  autoZIndex: js.UndefOr[Boolean] = js.undefined,                    // default: true
-  appendTo:   js.UndefOr[SelfPosition | HTMLElement] = js.undefined, // default: document.body
-  onHide:     js.UndefOr[Callback] = js.undefined,
-  onShow:     js.UndefOr[Callback] = js.undefined,
-  modifiers:  Seq[TagMod] = Seq.empty
-) extends GenericComponentPAF[PopupMenu.PopupMenuProps, PopupMenu, PopupMenu.Facade]:
-  override protected def cprops                                                    = PopupMenu.props(this)
-  override protected val component
-    : ComponentWithFacade[PopupMenu.PopupMenuProps, Null, PopupMenu.Facade, Props] =
-    PopupMenu.component
+  model:                           Reusable[List[MenuItem]],
+  id:                              js.UndefOr[String] = js.undefined,
+  clazz:                           js.UndefOr[Css] = js.undefined,
+  baseZIndex:                      js.UndefOr[Int] = js.undefined,                        // default: 0
+  autoZIndex:                      js.UndefOr[Boolean] = js.undefined,                    // default: true
+  appendTo:                        js.UndefOr[SelfPosition | HTMLElement] = js.undefined, // default: document.body
+  onHide:                          js.UndefOr[Callback] = js.undefined,
+  onShow:                          js.UndefOr[Callback] = js.undefined,
+  modifiers:                       Seq[TagMod] = Seq.empty,
+  private[primereact] val menuRef: Option[
+    Ref.Handle[Js.RawMounted[PopupMenu.PopupMenuProps, Null] & PopupMenu.Facade]
+  ] = None
+) extends ReactFnProps[PopupMenu](PopupMenu.component) {
+  def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+  def withMods(mods:          TagMod*)     = addModifiers(mods)
+  def apply(mods:             TagMod*)     = addModifiers(mods)
 
-  override def addModifiers(modifiers: Seq[TagMod]): PopupMenu =
-    copy(modifiers = this.modifiers ++ modifiers)
-
-  def withMods(mods: TagMod*) = addModifiers(mods)
+  def withRef(
+    ref: Ref.ToJsComponent[
+      PopupMenu.PopupMenuProps,
+      Null,
+      facade.React.Component[PopupMenu.PopupMenuProps, Null] & PopupMenu.Facade
+    ]
+  ): PopupMenu = copy(menuRef = Some(ref))
+}
 
 object PopupMenu {
   @js.native
@@ -71,19 +76,24 @@ object PopupMenu {
     var onShow: js.UndefOr[js.Function1[ReactEventFrom[Element], Unit]] = js.native
   }
 
-  private def props(pm: PopupMenu): PopupMenuProps = {
-    val r = (new js.Object).asInstanceOf[PopupMenuProps]
-    r.model = pm.model.toJSArray
-    r.popup = true
-    pm.clazz.foreach(v => r.className = v.htmlClass)
-    pm.baseZIndex.foreach(v => r.baseZIndex = v)
-    pm.autoZIndex.foreach(v => r.autoZIndex = v)
-    pm.appendTo.foreach(v => r.appendTo = v.asInstanceOf[Any])
-    pm.onHide.foreach(v => r.onHide = _ => v.runNow())
-    pm.onShow.foreach(v => r.onShow = _ => v.runNow())
-    r
-  }
-
-  val component =
+  private val rawComponent =
     JsComponent[PopupMenuProps, Children.None, Null](RawPopupMenu).addFacade[Facade]
+
+  private val component = ScalaFnComponent[PopupMenu] { pm =>
+    for modelArray <- useMemo(pm.model)(_.value.map(_.asInstanceOf[Any]).toJSArray)
+    yield {
+      val r = (new js.Object).asInstanceOf[PopupMenuProps]
+      r.model = modelArray.value.asInstanceOf[js.Array[MenuItem]]
+      r.popup = true
+      pm.id.foreach(v => r.asInstanceOf[js.Dynamic].id = v.asInstanceOf[js.Any])
+      pm.clazz.foreach(v => r.className = v.htmlClass)
+      pm.baseZIndex.foreach(v => r.baseZIndex = v)
+      pm.autoZIndex.foreach(v => r.autoZIndex = v)
+      pm.appendTo.foreach(v => r.appendTo = v.asInstanceOf[Any])
+      pm.onHide.foreach(v => r.onHide = _ => v.runNow())
+      pm.onShow.foreach(v => r.onShow = _ => v.runNow())
+      new AttrsBuilder(r).toJs(pm.modifiers)
+      pm.menuRef.fold(rawComponent)(rawComponent.withRef).applyGeneric(r)()
+    }
+  }
 }

--- a/prime-react/src/main/scala/lucuma/react/primereact/PopupTieredMenu.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/PopupTieredMenu.scala
@@ -4,58 +4,68 @@
 package lucuma.react.primereact
 
 import japgolly.scalajs.react.*
-import japgolly.scalajs.react.CtorType.Props
-import japgolly.scalajs.react.component.Js.ComponentWithFacade
+import japgolly.scalajs.react.component.Js
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.*
 import org.scalajs.dom.*
 
-import scalajs.js.annotation.JSImport
 import scalajs.js
 import scalajs.js.JSConverters.*
+import scalajs.js.annotation.JSImport
 
 // The PopupMenu and PopupTieredMenu have the same properties, events, etc. So
 // this shares the Facade and Props with the PopupMenu, and uses the same PopupMenuRef
 case class PopupTieredMenu(
-  model:      Seq[MenuItem],
-  id:         js.UndefOr[String] = js.undefined,
-  clazz:      js.UndefOr[Css] = js.undefined,
-  baseZIndex: js.UndefOr[Int] = js.undefined,                        // default: 0
-  autoZIndex: js.UndefOr[Boolean] = js.undefined,                    // default: true
-  appendTo:   js.UndefOr[SelfPosition | HTMLElement] = js.undefined, // default: document.body
-  onHide:     js.UndefOr[Callback] = js.undefined,
-  onShow:     js.UndefOr[Callback] = js.undefined,
-  modifiers:  Seq[TagMod] = Seq.empty
-) extends GenericComponentPAF[PopupMenu.PopupMenuProps, PopupTieredMenu, PopupMenu.Facade]:
-  override protected def cprops                                                    = PopupTieredMenu.props(this)
-  override protected val component
-    : ComponentWithFacade[PopupMenu.PopupMenuProps, Null, PopupMenu.Facade, Props] =
-    PopupTieredMenu.component
+  model:                           Reusable[List[MenuItem]],
+  id:                              js.UndefOr[String] = js.undefined,
+  clazz:                           js.UndefOr[Css] = js.undefined,
+  baseZIndex:                      js.UndefOr[Int] = js.undefined,                        // default: 0
+  autoZIndex:                      js.UndefOr[Boolean] = js.undefined,                    // default: true
+  appendTo:                        js.UndefOr[SelfPosition | HTMLElement] = js.undefined, // default: document.body
+  onHide:                          js.UndefOr[Callback] = js.undefined,
+  onShow:                          js.UndefOr[Callback] = js.undefined,
+  modifiers:                       Seq[TagMod] = Seq.empty,
+  private[primereact] val menuRef: Option[
+    Ref.Handle[Js.RawMounted[PopupMenu.PopupMenuProps, Null] & PopupMenu.Facade]
+  ] = None
+) extends ReactFnProps[PopupTieredMenu](PopupTieredMenu.component) {
+  def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+  def withMods(mods:          TagMod*)     = addModifiers(mods)
+  def apply(mods:             TagMod*)     = addModifiers(mods)
 
-  override def addModifiers(modifiers: Seq[TagMod]): PopupTieredMenu =
-    copy(modifiers = this.modifiers ++ modifiers)
-
-  def withMods(mods: TagMod*) = addModifiers(mods)
+  def withRef(
+    ref: Ref.ToJsComponent[
+      PopupMenu.PopupMenuProps,
+      Null,
+      facade.React.Component[PopupMenu.PopupMenuProps, Null] & PopupMenu.Facade
+    ]
+  ): PopupTieredMenu = copy(menuRef = Some(ref))
+}
 
 object PopupTieredMenu {
   @js.native
   @JSImport("primereact/tieredmenu/tieredmenu.esm", "TieredMenu")
-  object RawPopupTieredMenu extends js.Object
+  private object RawTieredMenu extends js.Object
 
-  private def props(pm: PopupTieredMenu): PopupMenu.PopupMenuProps = {
-    val r = (new js.Object).asInstanceOf[PopupMenu.PopupMenuProps]
-    r.model = pm.model.toJSArray
-    r.popup = true
-    pm.clazz.foreach(v => r.className = v.htmlClass)
-    pm.baseZIndex.foreach(v => r.baseZIndex = v)
-    pm.autoZIndex.foreach(v => r.autoZIndex = v)
-    pm.appendTo.foreach(v => r.appendTo = v.asInstanceOf[Any])
-    pm.onHide.foreach(v => r.onHide = _ => v.runNow())
-    pm.onShow.foreach(v => r.onShow = _ => v.runNow())
-    r
-  }
-
-  val component =
-    JsComponent[PopupMenu.PopupMenuProps, Children.None, Null](RawPopupTieredMenu)
+  private val tieredMenuComponent =
+    JsComponent[PopupMenu.PopupMenuProps, Children.None, Null](RawTieredMenu)
       .addFacade[PopupMenu.Facade]
+
+  private val component = ScalaFnComponent[PopupTieredMenu] { pm =>
+    for modelArray <- useMemo(pm.model)(_.value.map(_.asInstanceOf[Any]).toJSArray)
+    yield {
+      val r = (new js.Object).asInstanceOf[PopupMenu.PopupMenuProps]
+      r.model = modelArray.value.asInstanceOf[js.Array[MenuItem]]
+      r.popup = true
+      pm.id.foreach(v => r.asInstanceOf[js.Dynamic].id = v.asInstanceOf[js.Any])
+      pm.clazz.foreach(v => r.className = v.htmlClass)
+      pm.baseZIndex.foreach(v => r.baseZIndex = v)
+      pm.autoZIndex.foreach(v => r.autoZIndex = v)
+      pm.appendTo.foreach(v => r.appendTo = v.asInstanceOf[Any])
+      pm.onHide.foreach(v => r.onHide = _ => v.runNow())
+      pm.onShow.foreach(v => r.onShow = _ => v.runNow())
+      new AttrsBuilder(r).toJs(pm.modifiers)
+      pm.menuRef.fold(tieredMenuComponent)(tieredMenuComponent.withRef).applyGeneric(r)()
+    }
+  }
 }

--- a/prime-react/src/main/scala/lucuma/react/primereact/SplitButton.scala
+++ b/prime-react/src/main/scala/lucuma/react/primereact/SplitButton.scala
@@ -15,7 +15,9 @@ import scalajs.js
 import scalajs.js.JSConverters.*
 
 final case class SplitButton(
-  model:           List[MenuItem],
+  // Must be reference-stable across renders: primereact's menu effect has no equality guard, and
+  // Reusability[MenuItem] is byRef, so a fresh List each render loops with "Maximum update depth exceeded".
+  model:           Reusable[List[MenuItem]],
   label:           js.UndefOr[String] = js.undefined,
   icon:            js.UndefOr[Icon] = js.undefined,
   id:              js.UndefOr[String] = js.undefined,
@@ -47,39 +49,44 @@ object SplitButton {
 
   private val component =
     ScalaFnComponent[SplitButton] { props =>
-      val fullCss =
-        props.clazz.toOption.orEmpty |+|
-          props.size.cls |+|
-          props.severity.cls |+|
-          PrimeStyles.ButtonOutlined.when_(props.outlined) |+|
-          PrimeStyles.ButtonRaised.when_(props.raised) |+|
-          PrimeStyles.ButtonRounded.when_(props.rounded) |+|
-          PrimeStyles.ButtonText.when_(props.text)
+      // Rebuild the JS array when `props.model` signals a change.
+      // primereact's `TieredMenu` runs a `useEffect([props.model])` that calls `setState`,
+      // so the array must keep a stable reference across renders or the component loops.
+      for modelArray <- useMemo(props.model)(_.value.map(_.asInstanceOf[Any]).toJSArray)
+      yield
+        val fullCss =
+          props.clazz.toOption.orEmpty |+|
+            props.size.cls |+|
+            props.severity.cls |+|
+            PrimeStyles.ButtonOutlined.when_(props.outlined) |+|
+            PrimeStyles.ButtonRaised.when_(props.raised) |+|
+            PrimeStyles.ButtonRounded.when_(props.rounded) |+|
+            PrimeStyles.ButtonText.when_(props.text)
 
-      val iconWithClass         =
-        props.icon.map(_.toPrimeWithClass(PrimeStyles.ButtonIcon))
-      val dropdownIconWithClass =
-        props.dropdownIcon.map(_.toPrimeWithClass(PrimeStyles.ButtonIcon))
+        val iconWithClass         =
+          props.icon.map(_.toPrimeWithClass(PrimeStyles.ButtonIcon))
+        val dropdownIconWithClass =
+          props.dropdownIcon.map(_.toPrimeWithClass(PrimeStyles.ButtonIcon))
 
-      CSplitButton
-        .model(props.model.map(_.asInstanceOf[Any]).toJSArray)
-        .onClick(e => props.onClick >> props.onClickE(e))
-        .applyOrNot(props.label, _.label(_))
-        .applyOrNot(props.id, _.id(_))
-        .applyOrNot(iconWithClass, _.icon(_))
-        .applyOrNot(dropdownIconWithClass, _.dropdownIcon(_))
-        .applyOrNot(fullCss, (c, p) => c.className(p.htmlClass))
-        .applyOrNot(props.buttonClass, (c, p) => c.buttonClassName(p.htmlClass))
-        .applyOrNot(props.menuButtonClass, (c, p) => c.menuButtonClassName(p.htmlClass))
-        .applyOrNot(props.tooltip, _.tooltip(_))
-        .applyOrNot(props.disabled, _.disabled(_))
-        .applyOrNot(props.loading, _.loading(_))
-        .applyOrNot(props.loadingIcon, (c, p) => c.loadingIcon(p.toPrime))
-        .applyOrNot(
-          props.tooltipOptions,
-          (c, p) => c.tooltipOptions(p.asInstanceOf[CTooltipOptions])
-        )(
-          props.modifiers.toTagMod
-        )
+        CSplitButton
+          .model(modelArray.value)
+          .onClick(e => props.onClick >> props.onClickE(e))
+          .applyOrNot(props.label, _.label(_))
+          .applyOrNot(props.id, _.id(_))
+          .applyOrNot(iconWithClass, _.icon(_))
+          .applyOrNot(dropdownIconWithClass, _.dropdownIcon(_))
+          .applyOrNot(fullCss, (c, p) => c.className(p.htmlClass))
+          .applyOrNot(props.buttonClass, (c, p) => c.buttonClassName(p.htmlClass))
+          .applyOrNot(props.menuButtonClass, (c, p) => c.menuButtonClassName(p.htmlClass))
+          .applyOrNot(props.tooltip, _.tooltip(_))
+          .applyOrNot(props.disabled, _.disabled(_))
+          .applyOrNot(props.loading, _.loading(_))
+          .applyOrNot(props.loadingIcon, (c, p) => c.loadingIcon(p.toPrime))
+          .applyOrNot(
+            props.tooltipOptions,
+            (c, p) => c.tooltipOptions(p.asInstanceOf[CTooltipOptions])
+          )(
+            props.modifiers.toTagMod
+          )
     }
 }


### PR DESCRIPTION
 React compares dependency arrays by reference. The facade built a fresh `js.Array` on every render (model.toJSArray), so the dep changed every render.  The loop is:

```                                                                                                                                                                                   
 1. Parent re-renders (the tile doing async work / churning).                                                                                                                                             
 2. The facade re-renders and builds a fresh js.Array for mode.                                                                                                           
 3. TieredMenu's effect dep [props.model, ...] — compared by React by reference — sees a new array → effect runs.                                                                                         
 4. Effect calls setProcessedItems(...) → that's the setState. It schedules a re-render of TieredMenu.                                                                                                    
 5. Go to 1. 
 ```

There are a few alternatives to solve this but it is hard to make a generic solution as `MenuItem` is a generic `js.Object` and transforming it to a scala ADT would require defining a  generic`Reusablity` for `MenuItem` that contains `Callbacks` and `VdomNode` entries

The proposed solution is to pass a `Reusable[List[MenuItem]]` rather than the plain list. This moves the definition of when the menu item is reusable to the caller which at the end is the one that knows when to re-render

I'm not too happy about putting a `Reusable` in the props but we have a similar case for Chart and it is likely the most honest take