### PR TITLE
Fix v9 tables truncating to 10 rows by default

### DIFF
--- a/tanstack-table/src/main/scala/lucuma/react/table/TableHook.scala
+++ b/tanstack-table/src/main/scala/lucuma/react/table/TableHook.scala
@@ -36,10 +36,26 @@ object TableHook:
       )
     )
 
+  // With `paginatedRowModel` always wired, v9's default pagination state ({pageIndex: 0,
+  // pageSize: 10}) would silently truncate every table to its first 10 rows. Default to
+  // pageSize Infinity (which v9 treats as "don't slice") unless the caller provided its own
+  // pagination state. The public facade doesn't expose pagination yet, so today this always
+  // applies; the guard future-proofs against it being added.
+  private def ensureUnpaginatedByDefault(options: js.Dynamic): Unit =
+    val statePagination        =
+      !js.isUndefined(options.state) && !js.isUndefined(options.state.pagination)
+    val initialStatePagination =
+      !js.isUndefined(options.initialState) && !js.isUndefined(options.initialState.pagination)
+    if !statePagination && !initialStatePagination then
+      if js.isUndefined(options.initialState) then options.initialState = js.Dynamic.literal()
+      options.initialState.pagination =
+        js.Dynamic.literal(pageIndex = 0, pageSize = Double.PositiveInfinity)
+
   private def useReactTableJs[T, TM, CM, TF](
     options: TableOptionsJs[T, TM, CM, TF]
   ): raw.buildLibTypesMod.Table[T] =
     options.asInstanceOf[js.Dynamic].updateDynamic("features")(defaultFeatures())
+    ensureUnpaginatedByDefault(options.asInstanceOf[js.Dynamic])
     ReactTableRaw.useTable(options).asInstanceOf[instance.Table[T]]
 
   def useReactTable[T, TM, CM, TF](

--- a/tanstack-table/src/test/scala/lucuma/react/table/TableRenderSuite.scala
+++ b/tanstack-table/src/test/scala/lucuma/react/table/TableRenderSuite.scala
@@ -67,6 +67,20 @@ class TableRenderSuite extends FunSuite:
         """<table><caption></caption><tbody><tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>25</td></tr></tbody></table>"""
       m.outerHTML.assert(expected)
 
+  test("v9 table renders all rows, not just the default 10-row page"):
+    // v9 always wires the paginated row model; without the facade's pageSize=Infinity default,
+    // getRowModel() would slice to tanstack's default pageSize of 10 and drop rows 11+.
+    val manyPeople   = Reusable.always((1 to 15).toList.map(i => Person(i, s"P$i", 20 + i)))
+    val manyRowsComp = ScalaFnComponent[Unit]: _ =>
+      for
+        rows  <- useMemo(manyPeople)(identity)
+        cols  <- useMemo(columns)(identity)
+        table <- useReactTable(TableOptions(cols, rows))
+      yield rowsHtml(table)
+    ReactTestUtils.withRenderedSync(manyRowsComp()): m =>
+      val expectedRows = (1 to 15).map(i => s"<tr><td>P$i</td><td>${20 + i}</td></tr>").mkString
+      m.outerHTML.assert(s"<table><caption></caption><tbody>$expectedRows</tbody></table>")
+
   test("v9 table sorts rows by the initial sorting state"):
     // Ascending by age: Bob(25) must precede Alice(30) — different from data order (Alice, Bob),
     // so this proves the sort is actually applied. The <caption> reads getState().sorting, which


### PR DESCRIPTION
Fixes a pagination default that truncates tables